### PR TITLE
feat: mission objective display UI for activities 5 to 9

### DIFF
--- a/Assets/Data/Activity 6/Dot Product/Level 1.asset
+++ b/Assets/Data/Activity 6/Dot Product/Level 1.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c70d44bbc2c7bd44dbfe14795d0a7d1f, type: 3}
   m_Name: Level 1
   m_EditorClassIdentifier: 
+  numberOfTests: 1
   satelliteDishVectorMin: {x: 0, y: 0, z: 0}
   satelliteDishVectorMax: {x: 5, y: 5, z: 5}
   targetObjectVectorMin: {x: 5, y: 5, z: 5}

--- a/Assets/Data/Activity 7/Center Of Mass/Level 1.asset
+++ b/Assets/Data/Activity 7/Center Of Mass/Level 1.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2f740ad140950374391a25be67b643a8, type: 3}
   m_Name: Level 1
   m_EditorClassIdentifier: 
+  numberOfTests: 1
   numberOfMasses: 3
   coordThreshold: 3
   massMinVal: 1

--- a/Assets/Data/Activity 7/Elastic Inelastic Collision/Level 1.asset
+++ b/Assets/Data/Activity 7/Elastic Inelastic Collision/Level 1.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 564c3f1676a32df4abdc9f41457c0d20, type: 3}
   m_Name: Level 1
   m_EditorClassIdentifier: 
-  numberOfTests: 0
+  numberOfTests: 1
   massMinVal: 1
   massMaxVal: 25
   velocityMinVal: 0

--- a/Assets/Scenes/Activity 5.unity
+++ b/Assets/Scenes/Activity 5.unity
@@ -6871,6 +6871,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
   player: {fileID: 950148098}
+  activityFiveManager: {fileID: 931427138}
   appleMotionView: {fileID: 2099505144}
   rockMotionView: {fileID: 1984238574}
   boatMotionView: {fileID: 1963148713}
@@ -29381,7 +29382,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
   activityPauseMenuUI: {fileID: 836714815}
-  missionObjectiveDisplayUI: {fileID: 0}
+  missionObjectiveDisplayUI: {fileID: 1253221695}
   forceLevelOne: {fileID: 11400000, guid: c355a1a08462f5a49b490ee49d15f1be, type: 2}
   forceLevelTwo: {fileID: 11400000, guid: bff2943d80c5ea54b8ce149f51408fa8, type: 2}
   forceLevelThree: {fileID: 11400000, guid: b1430d342e924ef4da02f0ea18259db0, type: 2}
@@ -34110,6 +34111,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 607430364}
+  - {fileID: 1253221693}
   - {fileID: 2099505141}
   - {fileID: 1984238573}
   - {fileID: 1963148712}
@@ -36180,6 +36182,253 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1251398045}
   m_CullTransparentMesh: 1
+--- !u!1001 &1253221692
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1110208136}
+    m_Modifications:
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Pivot.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_text
+      value: 'Mission: Investigate Forces'
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_fontSize
+      value: 44
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 44
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_VerticalAlignment
+      value: 256
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_HorizontalAlignment
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[0]
+      value: 
+      objectReference: {fileID: 2089233404}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[1]
+      value: 
+      objectReference: {fileID: 1946814990}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[2]
+      value: 
+      objectReference: {fileID: 1471855508}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[3]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[4]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[5]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3023334296229733518, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 675
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5315796215944149607, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Spacing
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5315796215944149607, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_ChildAlignment
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5569147877243941917, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_ChildAlignment
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7821929296905643461, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveDisplay
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2089233403}
+    - targetCorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1946814989}
+    - targetCorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1471855507}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+--- !u!224 &1253221693 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+  m_PrefabInstance: {fileID: 1253221692}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1253221694 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+  m_PrefabInstance: {fileID: 1253221692}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1253221695 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+  m_PrefabInstance: {fileID: 1253221692}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 44d870b00a1dd56469fe3f213572363e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1254358517
 GameObject:
   m_ObjectHideFlags: 0
@@ -40022,6 +40271,207 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1466109118}
   m_CullTransparentMesh: 1
+--- !u!1001 &1471855506
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1253221694}
+    m_Modifications:
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083381517881983902, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveToggle (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328605777689382417, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 625
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_text
+      value: Identify and Calculate for the Forces Acting on the Boat
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+--- !u!224 &1471855507 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1471855506}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1471855508 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1399766052664907407, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1471855506}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1472525880
 GameObject:
   m_ObjectHideFlags: 0
@@ -55736,6 +56186,207 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4125d18402b3523488e8aec9227713b5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1946814988
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1253221694}
+    m_Modifications:
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083381517881983902, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveToggle (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328605777689382417, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 625
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_text
+      value: Identify and Calculate for the Forces Acting on the Rock
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+--- !u!224 &1946814989 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1946814988}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1946814990 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1399766052664907407, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1946814988}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1953270453
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -63734,6 +64385,207 @@ MonoBehaviour:
   downForceTypeAnswerDisplay: {fileID: 1965423049}
   leftForceTypeAnswerDisplay: {fileID: 46397863}
   rightForceTypeAnswerDisplay: {fileID: 438640761}
+--- !u!1001 &2089233402
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1253221694}
+    m_Modifications:
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083381517881983902, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveToggle
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328605777689382417, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 625
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_text
+      value: Identify and Calculate for the Forces Acting on the Apple
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+--- !u!224 &2089233403 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 2089233402}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2089233404 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1399766052664907407, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 2089233402}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2091562560
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Activity 6.unity
+++ b/Assets/Scenes/Activity 6.unity
@@ -2146,6 +2146,253 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4340555707901484, guid: 48ad265f338caaf4da3a864816595b22, type: 3}
   m_PrefabInstance: {fileID: 109485556}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &109695014
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 544988004}
+    m_Modifications:
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Pivot.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_text
+      value: 'Mission: Reach the Drone Crash Site'
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_fontSize
+      value: 42
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 42
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_VerticalAlignment
+      value: 256
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_HorizontalAlignment
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[0]
+      value: 
+      objectReference: {fileID: 1412397064}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[1]
+      value: 
+      objectReference: {fileID: 403848378}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[2]
+      value: 
+      objectReference: {fileID: 244266686}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[3]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[4]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[5]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3023334296229733518, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 850
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5315796215944149607, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Spacing
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5315796215944149607, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_ChildAlignment
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5569147877243941917, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_ChildAlignment
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7821929296905643461, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveDisplay
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1412397063}
+    - targetCorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 403848377}
+    - targetCorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 244266685}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+--- !u!224 &109695015 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+  m_PrefabInstance: {fileID: 109695014}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &109695016 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+  m_PrefabInstance: {fileID: 109695014}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &109695017 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+  m_PrefabInstance: {fileID: 109695014}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 44d870b00a1dd56469fe3f213572363e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &110571981
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9804,6 +10051,208 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4345878849055200, guid: fa6105287f77b1240a0017f7d23434c2, type: 3}
   m_PrefabInstance: {fileID: 241139425}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &244266684
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 109695016}
+    m_Modifications:
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083381517881983902, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveToggle (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328605777689382417, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 720
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_text
+      value: Find the Crashed Drone and Determine the Net Work Exerted from its Force
+        vs. Displacement Graph Data (0/n)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+--- !u!224 &244266685 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 244266684}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &244266686 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1399766052664907407, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 244266684}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &246579140
 GameObject:
   m_ObjectHideFlags: 0
@@ -13583,6 +14032,208 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 403595563}
   m_CullTransparentMesh: 1
+--- !u!1001 &403848376
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 109695016}
+    m_Modifications:
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083381517881983902, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveToggle (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328605777689382417, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 720
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_text
+      value: Embark on the Satellite Truck and Monitor the Work Exerted by the Vehicle
+        (0/n)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+--- !u!224 &403848377 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 403848376}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &403848378 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1399766052664907407, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 403848376}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &410581324
 GameObject:
   m_ObjectHideFlags: 0
@@ -16511,6 +17162,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 415504487}
+  - {fileID: 109695015}
   - {fileID: 440995600}
   - {fileID: 1629270836}
   - {fileID: 1957497100}
@@ -45434,6 +46086,208 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1409898247}
   m_CullTransparentMesh: 1
+--- !u!1001 &1412397062
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 109695016}
+    m_Modifications:
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083381517881983902, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveToggle
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328605777689382417, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 720
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_text
+      value: Monitor the Satellite's Direction by Computing for the Dot Product on
+        the Satellite Control Panel (0/n)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+--- !u!224 &1412397063 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1412397062}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1412397064 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1399766052664907407, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1412397062}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1413912539
 GameObject:
   m_ObjectHideFlags: 0
@@ -49862,7 +50716,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
   activityPauseMenuUI: {fileID: 581559134}
-  missionObjectiveDisplayUI: {fileID: 0}
+  missionObjectiveDisplayUI: {fileID: 109695017}
   dotProductLevelOne: {fileID: 11400000, guid: 5ea46127ab9e6464081f644c7a3c4611, type: 2}
   dotProductLevelTwo: {fileID: 11400000, guid: cb2cc6800b781b7418f99ae61bd1d3f6, type: 2}
   dotProductLevelThree: {fileID: 11400000, guid: f682defc96b9a8e4eb263b6417f1804a, type: 2}

--- a/Assets/Scenes/Activity 7.unity
+++ b/Assets/Scenes/Activity 7.unity
@@ -7383,7 +7383,6 @@ GameObject:
   - component: {fileID: 229723914}
   - component: {fileID: 229723913}
   - component: {fileID: 229723912}
-  - component: {fileID: 229723911}
   m_Layer: 5
   m_Name: QuitButton
   m_TagString: Untagged
@@ -7411,20 +7410,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 75, y: 75}
   m_Pivot: {x: 1, y: 1}
---- !u!114 &229723911
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 229723909}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b76cca2280c95d447b1c8862f7ecb06c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
-  view: {fileID: 1808637246}
 --- !u!114 &229723912
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7468,7 +7453,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 229723913}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1808637250}
+        m_TargetAssemblyTypeName: MomentumImpulseForceView, Assembly-CSharp
+        m_MethodName: OnQuitButtonClick
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &229723913
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -9447,7 +9444,6 @@ GameObject:
   - component: {fileID: 291945073}
   - component: {fileID: 291945072}
   - component: {fileID: 291945071}
-  - component: {fileID: 291945074}
   m_Layer: 5
   m_Name: QuitButton
   m_TagString: Untagged
@@ -9518,7 +9514,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 291945072}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1919976341}
+        m_TargetAssemblyTypeName: CenterOfMassView, Assembly-CSharp
+        m_MethodName: OnQuitButtonClick
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &291945072
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -9557,20 +9565,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 291945069}
   m_CullTransparentMesh: 1
---- !u!114 &291945074
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 291945069}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b76cca2280c95d447b1c8862f7ecb06c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
-  view: {fileID: 1919976337}
 --- !u!1 &296760195
 GameObject:
   m_ObjectHideFlags: 0
@@ -16448,8 +16442,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 561166135}
-  - component: {fileID: 561166136}
   - component: {fileID: 561166137}
+  - component: {fileID: 561166138}
   m_Layer: 0
   m_Name: ControlPanel
   m_TagString: Untagged
@@ -16474,21 +16468,6 @@ Transform:
   - {fileID: 1412821906}
   m_Father: {fileID: 580816574}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &561166136
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 561166134}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cc6c976800ecae1409976f9b9bd3aab6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
-  viewUI: {fileID: 1808637246}
-  targetCamera: {fileID: 0}
 --- !u!65 &561166137
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -16510,6 +16489,22 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1.8, y: 2.2, z: 2}
   m_Center: {x: 7.45, y: 1, z: -14}
+--- !u!114 &561166138
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 561166134}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 12d6141a3ef8b1d4c97ed799bd48c046, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
+  viewUI: {fileID: 1808637246}
+  interactionDescription: Open Momentum-Impulse Terminal
+  isInteractableOnStart: 1
 --- !u!1 &568758601
 GameObject:
   m_ObjectHideFlags: 0
@@ -17071,7 +17066,7 @@ GameObject:
   m_Component:
   - component: {fileID: 580816574}
   m_Layer: 0
-  m_Name: Room Two
+  m_Name: MomentumImpulseForceRoom
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -17103,6 +17098,7 @@ Transform:
   - {fileID: 806635439}
   - {fileID: 789938757}
   - {fileID: 335337064}
+  - {fileID: 1280729968}
   m_Father: {fileID: 318878654}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &581055678
@@ -17966,7 +17962,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
   activityPauseMenuUI: {fileID: 1604709292}
-  missionObjectiveDisplayUI: {fileID: 0}
+  missionObjectiveDisplayUI: {fileID: 1827216990}
   centerOfMassLevelOne: {fileID: 11400000, guid: de692f829cfdf3b4eba3ba9bcdbb5fbb, type: 2}
   centerOfMassLevelTwo: {fileID: 11400000, guid: d987efae341064d409a7d46cb8c63e8b, type: 2}
   centerOfMassLevelThree: {fileID: 11400000, guid: e90dc77a478bd704185d9347835acd63, type: 2}
@@ -18722,6 +18718,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 16e0a50680ee1a44e82c74ddc623d600, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
+  player: {fileID: 1343904935}
+  activitySevenManager: {fileID: 599909560}
+  centerOfMassView: {fileID: 1919976341}
+  momentumImpulseForceView: {fileID: 1808637250}
+  elasticInelasticCollisionView: {fileID: 513545358}
+  centerOfMassTerminalEnvCamera: {fileID: 684228814}
+  impulseMomentumTerminalEnvCamera: {fileID: 1280729969}
+  collisionTerminalEnvCamera: {fileID: 1595827925}
   containerGlassOne: {fileID: 831378840}
   containerGlassTwo: {fileID: 817193379}
   powerSourceCubeOne: {fileID: 1669057063}
@@ -18729,15 +18734,15 @@ MonoBehaviour:
   roomOneGate: {fileID: 1280970713}
   roomOneGateBlocker: {fileID: 348885588}
   powerContainer: {fileID: 266883701}
-  roomOneControlPanel: {fileID: 1834523738}
+  centerOfMassTerminal: {fileID: 1834523740}
   roomTwoGate: {fileID: 903401379}
   roomTwoGateBlocker: {fileID: 1186431043}
   cubePusher: {fileID: 2085883923}
-  roomTwoControlPanel: {fileID: 561166136}
+  impulseMomentumTerminal: {fileID: 561166138}
   containerGlassThree: {fileID: 1140476439}
   dataModuleCube: {fileID: 1197807633}
   collisionVideoCamera: {fileID: 1749200825}
-  roomThreeControlPanel: {fileID: 1007296068}
+  collisionTerminal: {fileID: 1007296069}
   openGateColor: {fileID: 2100000, guid: fca5137d69433b34384d90276be08d8c, type: 2}
 --- !u!4 &629807486
 Transform:
@@ -19964,6 +19969,89 @@ Transform:
   - {fileID: 348885589}
   m_Father: {fileID: 865651412}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &684228812
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 684228813}
+  - component: {fileID: 684228814}
+  m_Layer: 0
+  m_Name: CenterOfMassEnvCam
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &684228813
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 684228812}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0.9063079, z: -0, w: -0.42261827}
+  m_LocalPosition: {x: 14, y: 2.5, z: -6}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 865651412}
+  m_LocalEulerAnglesHint: {x: 0, y: 230, z: 0}
+--- !u!20 &684228814
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 684228812}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
 --- !u!114 &687265149 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8434895306495210145, guid: 903d94adb8f7d7644bb511e919fc9de6, type: 3}
@@ -21274,6 +21362,208 @@ Light:
   m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
+--- !u!1001 &749757385
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1827216989}
+    m_Modifications:
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083381517881983902, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveToggle
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328605777689382417, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 780
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_text
+      value: Retrieve the power cube by computing for its center of mass on the Center
+        of Mass Terminal (0/n)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+--- !u!224 &749757386 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 749757385}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &749757387 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1399766052664907407, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 749757385}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &750657858
 GameObject:
   m_ObjectHideFlags: 0
@@ -25099,7 +25389,7 @@ GameObject:
   m_Component:
   - component: {fileID: 865651412}
   m_Layer: 0
-  m_Name: Room One
+  m_Name: CenterOfMassRoom
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -25130,6 +25420,7 @@ Transform:
   - {fileID: 1834523737}
   - {fileID: 607550733}
   - {fileID: 266883700}
+  - {fileID: 684228813}
   m_Father: {fileID: 318878654}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &870831199
@@ -26822,6 +27113,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1661389621}
+  - {fileID: 1827216988}
   - {fileID: 1919976338}
   - {fileID: 1808637247}
   - {fileID: 513545355}
@@ -29462,8 +29754,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1007296066}
-  - component: {fileID: 1007296068}
   - component: {fileID: 1007296067}
+  - component: {fileID: 1007296069}
   m_Layer: 0
   m_Name: ControlPanel
   m_TagString: Untagged
@@ -29510,7 +29802,7 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1.6731567, y: 1.9375161, z: 1.6561584}
   m_Center: {x: -12.495472, y: 0.8753403, z: -8.420765}
---- !u!114 &1007296068
+--- !u!114 &1007296069
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -29519,12 +29811,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 1007296065}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cc6c976800ecae1409976f9b9bd3aab6, type: 3}
+  m_Script: {fileID: 11500000, guid: 12d6141a3ef8b1d4c97ed799bd48c046, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
   viewUI: {fileID: 513545354}
-  targetCamera: {fileID: 0}
+  interactionDescription: Open Collision Terminal
+  isInteractableOnStart: 1
 --- !u!1 &1014583551
 GameObject:
   m_ObjectHideFlags: 0
@@ -29847,6 +30140,208 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 2
   m_VerticalFit: 0
+--- !u!1001 &1042382307
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1827216989}
+    m_Modifications:
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083381517881983902, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveToggle (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328605777689382417, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 780
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_text
+      value: Unlock the impulse momentum mechanism of the door containing the ships'
+        data module on the Impulse-Momentum Terminal (0/n)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+--- !u!224 &1042382308 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1042382307}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1042382309 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1399766052664907407, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1042382307}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1045003003
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -37110,6 +37605,89 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2da0c512f12947e489f739169773d7ca, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1280729967
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1280729968}
+  - component: {fileID: 1280729969}
+  m_Layer: 0
+  m_Name: MomentumImpulseEnvCam
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1280729968
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1280729967}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: 0.9238796, z: -0, w: -0.38268325}
+  m_LocalPosition: {x: 9, y: 2.5, z: -8}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 580816574}
+  m_LocalEulerAnglesHint: {x: 0, y: 225, z: 0}
+--- !u!20 &1280729969
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1280729967}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
 --- !u!1 &1280970713 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1791102037889338, guid: fa577da00fa6c43409027bfc2cb446f1, type: 3}
@@ -39158,6 +39736,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ee9e4f3b02feb8d41b90fffd774125ef, type: 3}
+--- !u!1 &1343904935 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5162706178862642002, guid: ee9e4f3b02feb8d41b90fffd774125ef, type: 3}
+  m_PrefabInstance: {fileID: 1343904934}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1352605254
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -41324,7 +41907,6 @@ GameObject:
   - component: {fileID: 1429802560}
   - component: {fileID: 1429802559}
   - component: {fileID: 1429802558}
-  - component: {fileID: 1429802557}
   m_Layer: 5
   m_Name: QuitButton
   m_TagString: Untagged
@@ -41352,20 +41934,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 75, y: 75}
   m_Pivot: {x: 1, y: 1}
---- !u!114 &1429802557
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1429802555}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b76cca2280c95d447b1c8862f7ecb06c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
-  view: {fileID: 513545354}
 --- !u!114 &1429802558
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -41409,7 +41977,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1429802559}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 513545358}
+        m_TargetAssemblyTypeName: ElasticInelasticCollisionView, Assembly-CSharp
+        m_MethodName: OnQuitButtonClick
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &1429802559
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -45865,6 +46445,89 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4685976674770980, guid: 40977f1f421b682459aa11ac70bbfc2c, type: 3}
   m_PrefabInstance: {fileID: 1593475676}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1595827923
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1595827924}
+  - component: {fileID: 1595827925}
+  m_Layer: 0
+  m_Name: CollisionTerminalEnvCam
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1595827924
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1595827923}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: -6, y: 2, z: -5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1909626231}
+  m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
+--- !u!20 &1595827925
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1595827923}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
 --- !u!1 &1598482728
 GameObject:
   m_ObjectHideFlags: 0
@@ -54050,6 +54713,256 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4755239091836874, guid: 230464eeaeb27b54c8c52bd67155038c, type: 3}
   m_PrefabInstance: {fileID: 1825492468}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1827216987
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 920782979}
+    m_Modifications:
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Pivot.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_text
+      value: 'Mission: Retrieve the Data Module'
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_fontSize
+      value: 42
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 42
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_VerticalAlignment
+      value: 256
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_HorizontalAlignment
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[0]
+      value: 
+      objectReference: {fileID: 749757387}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[1]
+      value: 
+      objectReference: {fileID: 1042382309}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[2]
+      value: 
+      objectReference: {fileID: 1827551061}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[3]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[4]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[5]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3023334296229733518, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5315796215944149607, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Spacing
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5315796215944149607, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_ChildAlignment
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5569147877243941917, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_ChildAlignment
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7821929296905643461, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveDisplay
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 749757386}
+    - targetCorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1042382308}
+    - targetCorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1827551060}
+    - targetCorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1993787878}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+--- !u!224 &1827216988 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+  m_PrefabInstance: {fileID: 1827216987}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1827216989 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+  m_PrefabInstance: {fileID: 1827216987}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1827216990 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+  m_PrefabInstance: {fileID: 1827216987}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 44d870b00a1dd56469fe3f213572363e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1827476976
 GameObject:
   m_ObjectHideFlags: 0
@@ -54101,6 +55014,208 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Padding: {x: -8, y: -5, z: -8, w: -5}
   m_Softness: {x: 0, y: 0}
+--- !u!1001 &1827551059
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1827216989}
+    m_Modifications:
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083381517881983902, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveToggle (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328605777689382417, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 780
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_text
+      value: Release the ships' data module from its container by overriding the
+        Collisions Terminal (0/n)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+--- !u!224 &1827551060 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1827551059}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1827551061 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1399766052664907407, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1827551059}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1828590582
 GameObject:
   m_ObjectHideFlags: 0
@@ -54397,8 +55512,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1834523737}
-  - component: {fileID: 1834523738}
   - component: {fileID: 1834523739}
+  - component: {fileID: 1834523740}
   m_Layer: 0
   m_Name: ControlPanel
   m_TagString: Untagged
@@ -54424,21 +55539,6 @@ Transform:
   - {fileID: 1591948936}
   m_Father: {fileID: 865651412}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1834523738
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1834523736}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cc6c976800ecae1409976f9b9bd3aab6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
-  viewUI: {fileID: 1919976337}
-  targetCamera: {fileID: 0}
 --- !u!65 &1834523739
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -54460,6 +55560,22 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1.5, y: 2, z: 1.5}
   m_Center: {x: 0, y: 1, z: 0}
+--- !u!114 &1834523740
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1834523736}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 12d6141a3ef8b1d4c97ed799bd48c046, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
+  viewUI: {fileID: 1919976337}
+  interactionDescription: Open Center of Mass Terminal
+  isInteractableOnStart: 1
 --- !u!1 &1836691178
 GameObject:
   m_ObjectHideFlags: 0
@@ -56562,7 +57678,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1909626231}
   m_Layer: 0
-  m_Name: Room Three
+  m_Name: CollisionRoom
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -56592,6 +57708,7 @@ Transform:
   - {fileID: 1251153257}
   - {fileID: 1810053874}
   - {fileID: 1007296066}
+  - {fileID: 1595827924}
   m_Father: {fileID: 318878654}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1913893148
@@ -58629,6 +59746,196 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1988882858}
   m_CullTransparentMesh: 1
+--- !u!1001 &1993787877
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1827216989}
+    m_Modifications:
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083381517881983902, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveToggle (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328605777689382417, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 780
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_text
+      value: Retrieve the Data Module
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+--- !u!224 &1993787878 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1993787877}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2004500784
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Activity 7.unity
+++ b/Assets/Scenes/Activity 7.unity
@@ -54823,7 +54823,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
       propertyPath: missionObjectiveList.Array.size
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
       propertyPath: missionObjectiveList.Array.data[0]
@@ -54840,7 +54840,7 @@ PrefabInstance:
     - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
       propertyPath: missionObjectiveList.Array.data[3]
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1993787880}
     - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
       propertyPath: missionObjectiveList.Array.data[4]
       value: 
@@ -59936,6 +59936,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
   m_PrefabInstance: {fileID: 1993787877}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1993787880 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1399766052664907407, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1993787877}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2004500784
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Activity 8.unity
+++ b/Assets/Scenes/Activity 8.unity
@@ -1567,6 +1567,256 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 73299043}
   m_CullTransparentMesh: 1
+--- !u!1001 &75510514
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1864591091}
+    m_Modifications:
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Pivot.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_text
+      value: 'Mission: Reboot the Ship''s Power'
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_fontSize
+      value: 42
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 42
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_VerticalAlignment
+      value: 256
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_HorizontalAlignment
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[0]
+      value: 
+      objectReference: {fileID: 819876573}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[1]
+      value: 
+      objectReference: {fileID: 853833528}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[2]
+      value: 
+      objectReference: {fileID: 1787785660}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[3]
+      value: 
+      objectReference: {fileID: 1863019569}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[4]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[5]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3023334296229733518, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5315796215944149607, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Spacing
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5315796215944149607, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_ChildAlignment
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5569147877243941917, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_ChildAlignment
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7821929296905643461, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveDisplay
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 819876572}
+    - targetCorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 853833527}
+    - targetCorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1787785659}
+    - targetCorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1863019567}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+--- !u!224 &75510515 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+  m_PrefabInstance: {fileID: 75510514}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &75510516 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+  m_PrefabInstance: {fileID: 75510514}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &75510517 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+  m_PrefabInstance: {fileID: 75510514}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 44d870b00a1dd56469fe3f213572363e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &79089972
 GameObject:
   m_ObjectHideFlags: 0
@@ -2952,10 +3202,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
   player: {fileID: 343719820}
+  activityEightManager: {fileID: 131536849}
+  momentOfInertiaView: {fileID: 1186192450}
+  torqueView: {fileID: 1286272749}
+  equilibriumView: {fileID: 1321808247}
   generatorCamera: {fileID: 882269659}
   fulcrumCamera: {fileID: 1262388510}
   weighingScaleCamera: {fileID: 1678373168}
-  generatorControlPanel: {fileID: 2046394057}
+  generatorControlTerminal: {fileID: 2046394059}
   slenderRodCenter: {fileID: 1994462879}
   slenderRodEnd: {fileID: 1377316940}
   rectangularPlateCenter: {fileID: 618620740}
@@ -2965,10 +3219,10 @@ MonoBehaviour:
   disk: {fileID: 796827204}
   weighingScaleRoomGate: {fileID: 1191228373}
   weighingScaleRoomGateBlocker: {fileID: 1422661174}
-  weighingScaleControlPanel: {fileID: 1922010936}
+  weighingScaleControlTerminal: {fileID: 1922010933}
   rebootRoomGate: {fileID: 1811477281}
   rebootRoomGateBlocker: {fileID: 515367198}
-  equilibriumControlPanel: {fileID: 141262790}
+  equilibriumControlTerminal: {fileID: 141262791}
   rebootButton: {fileID: 1059166557}
   rebootButtonGlassCover: {fileID: 1667797453}
   openGateColor: {fileID: 2100000, guid: fca5137d69433b34384d90276be08d8c, type: 2}
@@ -3187,6 +3441,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
   activityPauseMenuUI: {fileID: 530044382}
+  missionObjectiveDisplayUI: {fileID: 75510517}
   momentOfInertiaLevelOne: {fileID: 11400000, guid: 8cf7fd1c9d0bccf4099621d449f633b3, type: 2}
   momentOfInertiaLevelTwo: {fileID: 11400000, guid: ab1f748d07720744d8948e997b534f68, type: 2}
   momentOfInertiaLevelThree: {fileID: 11400000, guid: 0fb729e5b66484347aaa72f67a065e9d, type: 2}
@@ -3769,7 +4024,7 @@ PrefabInstance:
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 4071454634996603655, guid: c307df270aadc074992821aa7848cf1a, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 141262790}
+      addedObject: {fileID: 141262791}
   m_SourcePrefab: {fileID: 100100000, guid: c307df270aadc074992821aa7848cf1a, type: 3}
 --- !u!4 &141262788 stripped
 Transform:
@@ -3781,7 +4036,7 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 4071454634996603655, guid: c307df270aadc074992821aa7848cf1a, type: 3}
   m_PrefabInstance: {fileID: 141262787}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &141262790
+--- !u!114 &141262791
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3790,12 +4045,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 141262789}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cc6c976800ecae1409976f9b9bd3aab6, type: 3}
+  m_Script: {fileID: 11500000, guid: 12d6141a3ef8b1d4c97ed799bd48c046, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
   viewUI: {fileID: 1321808243}
-  targetCamera: {fileID: 1678373168}
+  interactionDescription: Open Equilibrium Control Terminal
+  isInteractableOnStart: 1
 --- !u!1001 &143681856
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -18560,6 +18816,208 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4929611780340128, guid: 52ad5c9c020a19c4bb74de3a99cf0974, type: 3}
   m_PrefabInstance: {fileID: 805607534}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &819876571
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 75510516}
+    m_Modifications:
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083381517881983902, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveToggle
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328605777689382417, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 780
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_text
+      value: Fix the ship's generator by calibrating its moment of inertia calculation
+        module on the Generator Control Terminal (0/n)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+--- !u!224 &819876572 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 819876571}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &819876573 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1399766052664907407, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 819876571}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &821163762
 GameObject:
   m_ObjectHideFlags: 0
@@ -19061,6 +19519,208 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4924130287515698, guid: ba75f6548b81ad440be3522e8695d23c, type: 3}
   m_PrefabInstance: {fileID: 842740257}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &853833526
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 75510516}
+    m_Modifications:
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083381517881983902, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveToggle (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328605777689382417, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 780
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_text
+      value: Fix the bolts of the weighing scale's fulcrum by calibrating its torque
+        calculation module on the Weighing Scale Terminal (0/n)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+--- !u!224 &853833527 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 853833526}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &853833528 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1399766052664907407, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 853833526}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &857870669 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7729497167425568121, guid: 16f0b8faf6847b44b9331828a42f5496, type: 3}
@@ -42895,6 +43555,208 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4900555179083176, guid: e6037065a7ca30841ba445cefd3ad5f8, type: 3}
   m_PrefabInstance: {fileID: 1787155251}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1787785658
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 75510516}
+    m_Modifications:
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083381517881983902, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveToggle (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328605777689382417, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 780
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_text
+      value: Ensure power equilibrium on switch by calibrating the equilibrium calculation
+        module of the Equilibrium Control Terminal (0/n)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+--- !u!224 &1787785659 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1787785658}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1787785660 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1399766052664907407, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1787785658}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1789207611
 GameObject:
   m_ObjectHideFlags: 0
@@ -45054,6 +45916,207 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1859544908}
   m_CullTransparentMesh: 1
+--- !u!1001 &1863019566
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 75510516}
+    m_Modifications:
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083381517881983902, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveToggle (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328605777689382417, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 780
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_text
+      value: Press the Reboot Button
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+--- !u!224 &1863019567 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1863019566}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1863019569 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1399766052664907407, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1863019566}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1863260819 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7729497167425568121, guid: 16f0b8faf6847b44b9331828a42f5496, type: 3}
@@ -45270,6 +46333,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1376423161}
+  - {fileID: 75510515}
   - {fileID: 1186192447}
   - {fileID: 1286272746}
   - {fileID: 1321808246}
@@ -46737,14 +47801,14 @@ PrefabInstance:
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 4071454634996603655, guid: c307df270aadc074992821aa7848cf1a, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1922010936}
+      addedObject: {fileID: 1922010933}
   m_SourcePrefab: {fileID: 100100000, guid: c307df270aadc074992821aa7848cf1a, type: 3}
 --- !u!4 &1922010932 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3732189724793061821, guid: c307df270aadc074992821aa7848cf1a, type: 3}
   m_PrefabInstance: {fileID: 1922010931}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1922010936
+--- !u!114 &1922010933
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -46753,12 +47817,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 565742724}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cc6c976800ecae1409976f9b9bd3aab6, type: 3}
+  m_Script: {fileID: 11500000, guid: 12d6141a3ef8b1d4c97ed799bd48c046, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
   viewUI: {fileID: 1286272745}
-  targetCamera: {fileID: 1262388510}
+  interactionDescription: Open Weighing Scale Terminal
+  isInteractableOnStart: 1
 --- !u!1001 &1924752670
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -48800,7 +49865,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2046394056}
   - component: {fileID: 2046394058}
-  - component: {fileID: 2046394057}
+  - component: {fileID: 2046394059}
   m_Layer: 0
   m_Name: GeneratorControlPanel
   m_TagString: Untagged
@@ -48824,21 +49889,6 @@ Transform:
   - {fileID: 563048959}
   m_Father: {fileID: 1360385912}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2046394057
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2046394055}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cc6c976800ecae1409976f9b9bd3aab6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
-  viewUI: {fileID: 1186192446}
-  targetCamera: {fileID: 882269659}
 --- !u!65 &2046394058
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -48860,6 +49910,22 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 2.5, y: 3, z: 2.5}
   m_Center: {x: 0, y: 1, z: 0}
+--- !u!114 &2046394059
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2046394055}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 12d6141a3ef8b1d4c97ed799bd48c046, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
+  viewUI: {fileID: 1186192446}
+  interactionDescription: Open Generator Control Terminal
+  isInteractableOnStart: 1
 --- !u!1001 &2047321459
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Activity 9.unity
+++ b/Assets/Scenes/Activity 9.unity
@@ -1148,7 +1148,7 @@ PrefabInstance:
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 4071454634996603655, guid: c307df270aadc074992821aa7848cf1a, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1031234920}
+      addedObject: {fileID: 1031234917}
   m_SourcePrefab: {fileID: 100100000, guid: c307df270aadc074992821aa7848cf1a, type: 3}
 --- !u!4 &76200724 stripped
 Transform:
@@ -5698,6 +5698,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1788855194}
+  - {fileID: 445329059}
   - {fileID: 827610058}
   - {fileID: 87725940}
   - {fileID: 1419825099}
@@ -6269,6 +6270,250 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 406727758}
   m_CullTransparentMesh: 1
+--- !u!1001 &445329058
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 378328415}
+    m_Modifications:
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Pivot.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_text
+      value: 'Mission: Successfully Land in TERRA'
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_fontSize
+      value: 42
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 42
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_VerticalAlignment
+      value: 256
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133685506131951791, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_HorizontalAlignment
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[0]
+      value: 
+      objectReference: {fileID: 1658631001}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[1]
+      value: 
+      objectReference: {fileID: 1296851307}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[2]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[3]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[4]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: missionObjectiveList.Array.data[5]
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3023334296229733518, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 880
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5315796215944149607, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Spacing
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5315796215944149607, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_ChildAlignment
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5569147877243941917, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_ChildAlignment
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7821929296905643461, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveDisplay
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8507020352350750498, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1658631000}
+    - targetCorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1296851306}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+--- !u!224 &445329059 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1643769932000434948, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+  m_PrefabInstance: {fileID: 445329058}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &445329060 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5030105328683497734, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+  m_PrefabInstance: {fileID: 445329058}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &445329061 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2432322951581046070, guid: 81d1c54cc4d9c9e4f9e8f50289305090, type: 3}
+  m_PrefabInstance: {fileID: 445329058}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 44d870b00a1dd56469fe3f213572363e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &449250820
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11060,7 +11305,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
   activityPauseMenuUI: {fileID: 1419825100}
-  missionObjectiveDisplayUI: {fileID: 0}
+  missionObjectiveDisplayUI: {fileID: 445329061}
   gravityLevelOne: {fileID: 11400000, guid: a776c007d2fe1774ba310eec300d8983, type: 2}
   gravityLevelTwo: {fileID: 11400000, guid: f55e019442824064dac69d04485c96e3, type: 2}
   gravityLevelThree: {fileID: 11400000, guid: e4a69ed0644a38f42b0aa8401aa8ff13, type: 2}
@@ -15484,6 +15729,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
   player: {fileID: 2064286376}
+  activityNineManager: {fileID: 703970968}
+  gravityView: {fileID: 827610062}
+  gravityControlTerminal: {fileID: 1031234917}
   planetCamera: {fileID: 1346258447}
   spaceshipRTCamera: {fileID: 103360134}
   satelliteOneRTCamera: {fileID: 716719934}
@@ -15781,7 +16029,7 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 4071454634996603655, guid: c307df270aadc074992821aa7848cf1a, type: 3}
   m_PrefabInstance: {fileID: 76200723}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1031234920
+--- !u!114 &1031234917
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -15790,12 +16038,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 1031234916}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cc6c976800ecae1409976f9b9bd3aab6, type: 3}
+  m_Script: {fileID: 11500000, guid: 12d6141a3ef8b1d4c97ed799bd48c046, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   inputReader: {fileID: 11400000, guid: 814afce522f247f4f91d4ca5f861c36a, type: 2}
   viewUI: {fileID: 827610057}
-  targetCamera: {fileID: 1346258447}
+  interactionDescription: Open Gravity Control Terminal
+  isInteractableOnStart: 1
 --- !u!1001 &1039370257
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -19709,6 +19958,207 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1294383565}
   m_CullTransparentMesh: 1
+--- !u!1001 &1296851305
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 445329060}
+    m_Modifications:
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083381517881983902, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveToggle (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328605777689382417, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 780
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_text
+      value: Prepare for Departure for TERRA
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+--- !u!224 &1296851306 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1296851305}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1296851307 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1399766052664907407, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1296851305}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1300959747
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -23742,6 +24192,208 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: -20, y: -20}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1001 &1658630999
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 445329060}
+    m_Modifications:
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950206382883392359, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083381517881983902, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Name
+      value: MissionObjectiveToggle
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328605777689382417, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_PreferredWidth
+      value: 780
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_text
+      value: Calculate the Gravitational Potential Energy and Gravitational Force
+        of the satellite on the Gravity Control Terminal (0/n)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5985345344489021207, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6043434913028645641, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695949551449041741, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+--- !u!224 &1658631000 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4113137447853338363, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1658630999}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1658631001 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1399766052664907407, guid: 4a43c5d9a258bf94cb914bf8a71995e6, type: 3}
+  m_PrefabInstance: {fileID: 1658630999}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1664853048
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Activity 5/ActivityFiveEnvironmentManager.cs
+++ b/Assets/Scripts/Activity 5/ActivityFiveEnvironmentManager.cs
@@ -3,6 +3,9 @@ using UnityEngine;
 
 public class ActivityFiveEnvironmentManager : ActivityEnvironmentManager
 {
+	[Header("Activity Manager")]
+	[SerializeField] private ActivityFiveManager activityFiveManager;
+
 	[Header("Views")]
 	[SerializeField] private ForceMotionView appleMotionView;
 	[SerializeField] private ForceMotionView rockMotionView;
@@ -172,6 +175,8 @@ public class ActivityFiveEnvironmentManager : ActivityEnvironmentManager
 			appleTreeAreaIndicatorEffect.gameObject.SetActive(false);
 			interactableApples.SetInteractable(false);
 
+			activityFiveManager.SetMissionObjectiveDisplay(true);
+
 			appleMotionEnvironmentStateMachine.TransitionToState(AppleMotionEnvironmentState.None);
 		}
 		else
@@ -218,6 +223,8 @@ public class ActivityFiveEnvironmentManager : ActivityEnvironmentManager
 			rockAreaIndicatorEffect.gameObject.SetActive(false);
 			interactableRock.SetInteractable(false);
 
+			activityFiveManager.SetMissionObjectiveDisplay(true);
+
 			rockMotionEnvironmentStateMachine.TransitionToState(RockMotionEnvironmentState.None);
 		}
 		else
@@ -257,6 +264,8 @@ public class ActivityFiveEnvironmentManager : ActivityEnvironmentManager
 			// Deactivate area effect and interactable boat
 			boatAreaIndicatorEffect.gameObject.SetActive(false);
 			interactableBoat.SetInteractable(false);
+
+			activityFiveManager.SetMissionObjectiveDisplay(true);
 
 			boatMotionEnvironmentStateMachine.TransitionToState(BoatMotionEnvironmentState.None);
 		}

--- a/Assets/Scripts/Activity 5/ActivityFiveManager.cs
+++ b/Assets/Scripts/Activity 5/ActivityFiveManager.cs
@@ -200,7 +200,11 @@ public class ActivityFiveManager : ActivityManager
 	private void SubscribeForceMotionEvents()
 	{
 		// Apple Force Motion related events
-		appleMotionView.OpenViewEvent += () => isAppleMotionViewActive = true;
+		appleMotionView.OpenViewEvent += () =>
+		{
+			isAppleMotionViewActive = true;
+			SetMissionObjectiveDisplay(false);
+		};
 		appleMotionView.OpenViewEvent += () => UpdateSubActivityStateMachine(
 			appleForceMotionSubActivityStateMachine,
 			appleForceMotionSubActivityStateQueue,
@@ -208,7 +212,11 @@ public class ActivityFiveManager : ActivityManager
 			ref appleForceGivenData,
 			ref isAppleMotionSubActivityFinished
 			);
-		appleMotionView.QuitViewEvent += () => isAppleMotionViewActive = false;
+		appleMotionView.QuitViewEvent += () =>
+		{
+			isAppleMotionViewActive = false;
+			SetMissionObjectiveDisplay(true);
+		};
 		appleMotionView.SubmitForceAnswerEvent += (answer) => CheckForceAnswer(
 			answer,
 			appleForceGivenData,
@@ -227,7 +235,11 @@ public class ActivityFiveManager : ActivityManager
 		appleForceDiagramSubmissionStatusDisplay.ProceedEvent += UpdateAppleForceDiagramStateQueue;
 
 		// Rock Force Motion related events
-		rockMotionView.OpenViewEvent += () => isRockMotionViewActive = true;
+		rockMotionView.OpenViewEvent += () =>
+		{
+			isRockMotionViewActive = true;
+			SetMissionObjectiveDisplay(false);
+		};
 		rockMotionView.OpenViewEvent += () => UpdateSubActivityStateMachine(
 			rockForceMotionSubActivityStateMachine,
 			rockForceMotionSubActivityStateQueue,
@@ -235,7 +247,11 @@ public class ActivityFiveManager : ActivityManager
 			ref rockForceGivenData,
 			ref isRockMotionSubActivityFinished
 			);
-		rockMotionView.QuitViewEvent += () => isRockMotionViewActive = false;
+		rockMotionView.QuitViewEvent += () =>
+		{
+			isRockMotionViewActive = false;
+			SetMissionObjectiveDisplay(true);
+		};
 		rockMotionView.SubmitForceAnswerEvent += (answer) => CheckForceAnswer(
 			answer,
 			rockForceGivenData,
@@ -254,7 +270,11 @@ public class ActivityFiveManager : ActivityManager
 		rockForceDiagramSubmissionStatusDisplay.ProceedEvent += UpdateRockForceDiagramStateQueue;
 
 		// Boat Force Motion related events
-		boatMotionView.OpenViewEvent += () => isBoatMotionViewActive = true;
+		boatMotionView.OpenViewEvent += () =>
+		{
+			isBoatMotionViewActive = true;
+			SetMissionObjectiveDisplay(false);
+		};
 		boatMotionView.OpenViewEvent += () => UpdateSubActivityStateMachine(
 			boatForceMotionSubActivityStateMachine,
 			boatForceMotionSubActivityStateQueue,
@@ -262,7 +282,11 @@ public class ActivityFiveManager : ActivityManager
 			ref boatForceGivenData,
 			ref isBoatMotionSubActivityFinished
 			);
-		boatMotionView.QuitViewEvent += () => isBoatMotionViewActive = false;
+		boatMotionView.QuitViewEvent += () =>
+		{
+			isBoatMotionViewActive = false;
+			SetMissionObjectiveDisplay(true);
+		};
 		boatMotionView.SubmitForceAnswerEvent += (answer) => CheckForceAnswer(
 			answer,
 			boatForceGivenData,
@@ -443,6 +467,7 @@ public class ActivityFiveManager : ActivityManager
 		if (subactivityStateQueue.Count == 0)
 		{
 			forceSubActivityStateMachine.TransitionToState(ActivityFiveSubActivityState.None);
+			forceMotionView.gameObject.SetActive(false);
 			isSubActivityFinished = true;
 		}
 		else
@@ -463,6 +488,7 @@ public class ActivityFiveManager : ActivityManager
 
 			forceSubActivityStateMachine.TransitionToState(queueSubActivityHead);
 		}
+		UpdateMissionObjectiveDisplayUI();
 	}
 
 	#region Apple Motion
@@ -527,6 +553,8 @@ public class ActivityFiveManager : ActivityManager
 
 	public override void DisplayPerformanceView()
 	{
+		SetMissionObjectiveDisplay(false);
+
 		inputReader.SetUI();
 		performanceView.gameObject.SetActive(true);
 
@@ -604,6 +632,13 @@ public class ActivityFiveManager : ActivityManager
 				averageScoreThreshold: 2
 				)
 			);
+	}
+
+	private void UpdateMissionObjectiveDisplayUI()
+	{
+		if (isAppleMotionSubActivityFinished) missionObjectiveDisplayUI.ClearMissionObjective(0);
+		if (isRockMotionSubActivityFinished) missionObjectiveDisplayUI.ClearMissionObjective(1);
+		if (isBoatMotionSubActivityFinished) missionObjectiveDisplayUI.ClearMissionObjective(2);
 	}
 
 	protected override void HandleGameplayPause()

--- a/Assets/Scripts/Activity 6/ActivitySixEnvironmentManager.cs
+++ b/Assets/Scripts/Activity 6/ActivitySixEnvironmentManager.cs
@@ -75,6 +75,7 @@ public class ActivitySixEnvironmentManager : ActivityEnvironmentManager
 			Difficulty.Easy => 1,
 			Difficulty.Medium => 2,
 			Difficulty.Hard => 3,
+			_ => 0
 		};
 		for (int i = 0; i < numCycles; i++)
 		{
@@ -87,6 +88,7 @@ public class ActivitySixEnvironmentManager : ActivityEnvironmentManager
 	private void SetSatelliteEnvironmentState(bool isActive)
 	{
 		SetPlayerActivityState(!isActive);
+		activitySixManager.SetMissionObjectiveDisplay(!isActive);
 		satelliteEnvironmentCamera.gameObject.SetActive(isActive);
 		mainSatelliteCamera.gameObject.SetActive(isActive);
 		targetObjectCamera.gameObject.SetActive(isActive);
@@ -126,6 +128,8 @@ public class ActivitySixEnvironmentManager : ActivityEnvironmentManager
 			satelliteTruckAreaIndicatorEffect.gameObject.SetActive(false);
 			satelliteTruck.SetInteractable(false);
 
+			activitySixManager.SetMissionObjectiveDisplay(true);
+
 			desertEnvironmentStateMachine.TransitionToState(DesertEnvironmentState.None);
 
 			// Set crashed drone area active, and teleport player to specified spawn point on said area
@@ -142,6 +146,7 @@ public class ActivitySixEnvironmentManager : ActivityEnvironmentManager
 	private void SetCrashedDroneEnvironmentState(bool isActive)
 	{
 		SetPlayerActivityState(!isActive);
+		activitySixManager.SetMissionObjectiveDisplay(!isActive);
 		crashedDroneEnvironmentAreaCamera.gameObject.SetActive(isActive);
 	}
 }

--- a/Assets/Scripts/Activity 6/ActivitySixManager.cs
+++ b/Assets/Scripts/Activity 6/ActivitySixManager.cs
@@ -70,6 +70,7 @@ public class ActivitySixManager : ActivityManager
 	// Variables for keeping track of current number of tests
 	private int currentNumDotProductTests;
 	private int currentNumWorkGraphTests;
+	private int totalWorkGraphTests;
 
 	// Variables for tracking which view is currently active
 	private bool isDotProductViewActive;
@@ -122,11 +123,17 @@ public class ActivitySixManager : ActivityManager
 			Difficulty.Hard => 3,
 			_ => 0
 		};
+		totalWorkGraphTests = currentNumWorkGraphTests;
 
 		// Setting up views
 		dotProductView.SetupDotProductView(dotProductGivenData);
 		workView.SetupWorkView(workSubActivityGivenData, workSubActivityStateQueue.Peek());
 		workGraphInterpretationView.SetupWorkGraphInterpretationView(forceDisplacementGraphData, currentGraphTypeDisplayed);
+
+		// Update mission objective display
+		missionObjectiveDisplayUI.UpdateMissionObjectiveText(0, $"Monitor the Satellite's Direction by Computing for the Dot Product on the Satellite Control Panel ({currentDotProductLevel.numberOfTests - currentNumDotProductTests}/{currentDotProductLevel.numberOfTests})");
+		missionObjectiveDisplayUI.UpdateMissionObjectiveText(1, $"Embark on the Satellite Truck and Monitor the Work Exerted by the Vehicle ({currentWorkLevel.numberOfRepetitions * 3 - workSubActivityStateQueue.Count}/{currentWorkLevel.numberOfRepetitions * 3})");
+		missionObjectiveDisplayUI.UpdateMissionObjectiveText(2, $"Find the Crashed Drone and Determine the Net Work Exerted from its Force vs. Displacement Graph Data ({totalWorkGraphTests - currentNumWorkGraphTests}/{totalWorkGraphTests})");
 	}
 
 	private void Update()
@@ -166,8 +173,16 @@ public class ActivitySixManager : ActivityManager
 		dotProductSubmissionStatusDisplay.ProceedEvent += UpdateDotProductViewState;
 
 		workView.OpenViewEvent += UpdateWorkSubActivityStateMachine;
-		workView.OpenViewEvent += () => isWorkViewActive = true;
-		workView.QuitViewEvent += () => isWorkViewActive = false;
+		workView.OpenViewEvent += () =>
+		{
+			isWorkViewActive = true;
+			SetMissionObjectiveDisplay(false);
+		};
+		workView.QuitViewEvent += () =>
+		{
+			isWorkViewActive = false;
+			SetMissionObjectiveDisplay(true);
+		};
 		workView.SubmitAnswerEvent += CheckWorkSubActivityAnswers;
 		workSubmissionStatusDisplay.ProceedEvent += UpdateWorkViewState;
 
@@ -215,6 +230,7 @@ public class ActivitySixManager : ActivityManager
 		if (results.isAllCorrect())
 		{
 			dotProductSubmissionStatusDisplay.SetSubmissionStatus(true, "The submitted calculations are correct.");
+			missionObjectiveDisplayUI.UpdateMissionObjectiveText(0, $"Monitor the Satellite's Direction by Computing for the Dot Product on the Satellite Control Panel ({currentDotProductLevel.numberOfTests - currentNumDotProductTests}/{currentDotProductLevel.numberOfTests})");
 		}
 		else
 		{
@@ -310,6 +326,7 @@ public class ActivitySixManager : ActivityManager
 	private void UpdateWorkViewState()
 	{
 		workSubActivityStateQueue.Dequeue();
+		missionObjectiveDisplayUI.UpdateMissionObjectiveText(1, $"Embark on the Satellite Truck and Monitor the Work Exerted by the Vehicle ({currentWorkLevel.numberOfRepetitions * 3 - workSubActivityStateQueue.Count}/{currentWorkLevel.numberOfRepetitions * 3})");
 		if (workSubActivityStateQueue.Count > 0)
 		{
 			UpdateWorkSubActivityStateMachine();
@@ -388,6 +405,7 @@ public class ActivitySixManager : ActivityManager
 		if (result)
 		{
 			workGraphSubmissionStatusDisplay.SetSubmissionStatus(true, "The submitted calculations are correct.");
+			missionObjectiveDisplayUI.UpdateMissionObjectiveText(2, $"Find the Crashed Drone and Determine the Net Work Exerted from its Force vs. Displacement Graph Data ({totalWorkGraphTests - currentNumWorkGraphTests}/{totalWorkGraphTests})");
 		}
 		else
 		{

--- a/Assets/Scripts/Activity 7/ActivitySevenEnvironmentManager.cs
+++ b/Assets/Scripts/Activity 7/ActivitySevenEnvironmentManager.cs
@@ -1,8 +1,21 @@
 using UnityEngine;
 
-public class ActivitySevenEnvironmentManager : MonoBehaviour
+public class ActivitySevenEnvironmentManager : ActivityEnvironmentManager
 {
-    [Header("Room One")]
+	[Header("Activity Manager")]
+	[SerializeField] private ActivitySevenManager activitySevenManager;
+
+	[Header("Views")]
+	[SerializeField] CenterOfMassView centerOfMassView;
+	[SerializeField] MomentumImpulseForceView momentumImpulseForceView;
+	[SerializeField] ElasticInelasticCollisionView elasticInelasticCollisionView;
+
+    [Header("Environment Cameras")]
+    [SerializeField] private Camera centerOfMassTerminalEnvCamera;
+    [SerializeField] private Camera impulseMomentumTerminalEnvCamera;
+    [SerializeField] private Camera collisionTerminalEnvCamera;
+	
+	[Header("Center Of Mass Terminal Room Game Objects")]
     [SerializeField] private GameObject containerGlassOne;
 	[SerializeField] private GameObject containerGlassTwo;
     [SerializeField] private PowerSourceCube powerSourceCubeOne;
@@ -10,19 +23,19 @@ public class ActivitySevenEnvironmentManager : MonoBehaviour
     [SerializeField] private GameObject roomOneGate;
     [SerializeField] private GameObject roomOneGateBlocker;
     [SerializeField] private PowerSourceCubeContainer powerContainer;
-    [SerializeField] private InteractableControlPanel roomOneControlPanel;
+    [SerializeField] private InteractableViewOpenerObject centerOfMassTerminal;
 
-    [Header("Room Two")]
+    [Header("Impulse-Momentum Terminal Room Game Objects")]
 	[SerializeField] private GameObject roomTwoGate;
 	[SerializeField] private GameObject roomTwoGateBlocker;
     [SerializeField] private CubePusher cubePusher;
-	[SerializeField] private InteractableControlPanel roomTwoControlPanel;
+	[SerializeField] private InteractableViewOpenerObject impulseMomentumTerminal;
 
-    [Header("Room Three")]
+    [Header("Collision Terminal Room Game Objects")]
 	[SerializeField] private GameObject containerGlassThree;
 	[SerializeField] private DataModuleCube dataModuleCube;
     [SerializeField] private Camera collisionVideoCamera;
-	[SerializeField] private InteractableControlPanel roomThreeControlPanel;
+	[SerializeField] private InteractableViewOpenerObject collisionTerminal;
 
 	[Header("Gate Status Color Material")]
     [SerializeField] private Material openGateColor;
@@ -31,42 +44,44 @@ public class ActivitySevenEnvironmentManager : MonoBehaviour
 
 	void Start()
     {
-        // Room One Environment Events
-        ActivitySevenManager.RoomOneClearEvent += ReleasePowerCube;
-        PowerSourceCube.RetrieveEvent += () => canPlayerPlaceCube = true;
-        PowerSourceCubeContainer.InteractEvent += UpdateRoomOneGateState;
+		// Center of Mass Terminal Environment Events
+		centerOfMassView.OpenViewEvent += () => SetCenterOfMassTerminalEnvironmentState(true);
+		centerOfMassView.QuitViewEvent += () => SetCenterOfMassTerminalEnvironmentState(false);
+		activitySevenManager.CenterOfMassTerminalClearEvent += ClearCenterOfMassTerminalEnvironmentState;
+		powerSourceCubeOne.RetrieveEvent += () => canPlayerPlaceCube = true;
+		powerContainer.InteractEvent += UpdateCenterOfMassRoomGateState;
 
-        // Room Two Environment Events
-        ActivitySevenManager.RoomTwoClearEvent += UpdateRoomTwoGateState;
+		// Impulse Momentum Terminal Environment Events
+		momentumImpulseForceView.OpenViewEvent += () => SetImpulseMomentumTerminalEnvironmentState(true);
+		momentumImpulseForceView.QuitViewEvent += () => SetImpulseMomentumTerminalEnvironmentState(false);
+		activitySevenManager.MomentumImpulseTerminalClearEvent += ClearImpulseMomentumTerminalEnvironmentState;
 
-        // Room Three Environment Events
-        ActivitySevenManager.RoomThreeClearEvent += ReleaseDataModuleCube;
+		// Elastic Inelastic Collision Terminal Environment Events
+		elasticInelasticCollisionView.OpenViewEvent += () => SetCollisionTerminalEnvironmentState(true);
+		elasticInelasticCollisionView.QuitViewEvent += () => SetCollisionTerminalEnvironmentState(false);
+		activitySevenManager.CollisionTerminalClearEvent += ClearCollisionTerminalEnvironmentState;
     }
 
-    private void OnDisable()
-    {
-        // Room One Environment Events
-        ActivitySevenManager.RoomOneClearEvent -= ReleasePowerCube;
-        PowerSourceCube.RetrieveEvent -= () => canPlayerPlaceCube = true;
-        PowerSourceCubeContainer.InteractEvent -= UpdateRoomOneGateState;
+	#region Center of Mass Terminal Room
+	private void SetCenterOfMassTerminalEnvironmentState(bool isActive)
+	{
+		SetPlayerActivityState(!isActive);
+		activitySevenManager.SetMissionObjectiveDisplay(!isActive);
+		centerOfMassTerminalEnvCamera.gameObject.SetActive(isActive);
+	}
 
-        // Room Two Environment Events
-        ActivitySevenManager.RoomTwoClearEvent -= UpdateRoomTwoGateState;
-
-        // Room Three Environment Events
-        ActivitySevenManager.RoomThreeClearEvent -= ReleaseDataModuleCube;
-    }
-
-    #region Room One
-    private void ReleasePowerCube()
-    {
-        powerSourceCubeOne.SetInteractable(true);
-        powerContainer.SetInteractable(true);
+	private void ClearCenterOfMassTerminalEnvironmentState()
+	{
+		SetCenterOfMassTerminalEnvironmentState(false);
+		centerOfMassTerminal.SetInteractable(false);
+		impulseMomentumTerminal.SetInteractable(true);
+		// Release power cube
+		powerSourceCubeOne.SetInteractable(true);
+		powerContainer.SetInteractable(true);
 		containerGlassOne.gameObject.SetActive(false);
-        roomOneControlPanel.SetInteractable(false);
-    }
+	}
 
-    private void UpdateRoomOneGateState()
+    private void UpdateCenterOfMassRoomGateState()
     {
         if (canPlayerPlaceCube)
         {
@@ -83,26 +98,43 @@ public class ActivitySevenEnvironmentManager : MonoBehaviour
     }
 	#endregion
 
-	#region Room Two
-    private void UpdateRoomTwoGateState()
-    {
-        roomTwoControlPanel.SetInteractable(false);
-        // Open room two gate
-        OpenGate(roomTwoGate, roomTwoGateBlocker);
-        cubePusher.SetWorkState(true);
-    }
+	#region Impulse-Momentum Terminal Room
+	private void SetImpulseMomentumTerminalEnvironmentState(bool isActive)
+	{
+		SetPlayerActivityState(!isActive);
+		activitySevenManager.SetMissionObjectiveDisplay(!isActive);
+		impulseMomentumTerminalEnvCamera.gameObject.SetActive(isActive);
+	}
+
+	private void ClearImpulseMomentumTerminalEnvironmentState()
+	{
+		SetImpulseMomentumTerminalEnvironmentState(false);
+		impulseMomentumTerminal.SetInteractable(false);
+		collisionTerminal.SetInteractable(true);
+		// Open gate and activate pusher
+		OpenGate(roomTwoGate, roomTwoGateBlocker);
+		cubePusher.SetWorkState(true);
+	}
 
 	#endregion
 
-	#region Room Three
+	#region Collision Terminal Room
+	private void SetCollisionTerminalEnvironmentState(bool isActive)
+	{
+		SetPlayerActivityState(!isActive);
+		activitySevenManager.SetMissionObjectiveDisplay(!isActive);
+		collisionTerminalEnvCamera.gameObject.SetActive(isActive);
+	}
 
-    private void ReleaseDataModuleCube()
-    {
-        containerGlassThree.gameObject.SetActive(false);
-        dataModuleCube.SetInteractable(true);
+	private void ClearCollisionTerminalEnvironmentState()
+	{
+		SetCollisionTerminalEnvironmentState(false);
+		collisionTerminal.SetInteractable(false);
+		// Release data module cube
+		containerGlassThree.gameObject.SetActive(false);
+		dataModuleCube.SetInteractable(true);
 		collisionVideoCamera.gameObject.SetActive(true);
-        roomThreeControlPanel.SetInteractable(false);
-    }
+	}
 
 	#endregion
 

--- a/Assets/Scripts/Activity 7/ActivitySevenManager.cs
+++ b/Assets/Scripts/Activity 7/ActivitySevenManager.cs
@@ -199,6 +199,9 @@ public class ActivitySevenManager : ActivityManager
 {
 	public static Difficulty difficultyConfiguration;
 
+	public event Action CenterOfMassTerminalClearEvent;
+	public event Action MomentumImpulseTerminalClearEvent;
+	public event Action CollisionTerminalClearEvent;
 	public static event Action RoomOneClearEvent;
 	public static event Action RoomTwoClearEvent;
 	public static event Action RoomThreeClearEvent;
@@ -433,6 +436,7 @@ public class ActivitySevenManager : ActivityManager
 		{
 			inputReader.SetGameplay();
 			centerOfMassView.gameObject.SetActive(false);
+			CenterOfMassTerminalClearEvent?.Invoke();
 			RoomOneClearEvent?.Invoke();
 		}
 	}
@@ -623,6 +627,7 @@ public class ActivitySevenManager : ActivityManager
 		{
 			inputReader.SetGameplay();
 			momentumImpulseForceView.gameObject.SetActive(false);
+			MomentumImpulseTerminalClearEvent?.Invoke();
 			RoomTwoClearEvent?.Invoke();
 		}
 	}
@@ -758,6 +763,7 @@ public class ActivitySevenManager : ActivityManager
 		{
 			inputReader.SetGameplay();
 			elasticInelasticCollisionView.gameObject.SetActive(false);
+			CollisionTerminalClearEvent?.Invoke();
 			RoomThreeClearEvent?.Invoke();
 		}
 	}

--- a/Assets/Scripts/Activity 7/ActivitySevenManager.cs
+++ b/Assets/Scripts/Activity 7/ActivitySevenManager.cs
@@ -418,7 +418,6 @@ public class ActivitySevenManager : ActivityManager
 			}
 			centerOfMassSubmissionStatusDisplay.SetSubmissionStatus(true, displayText);
 
-			missionObjectiveDisplayUI.UpdateMissionObjectiveText(0, $"Retrieve the power cube by computing for its center of mass on the Center of Mass Terminal ({currentCenterOfMassLevel.numberOfTests - currentNumCenterOfMassTests}/{currentCenterOfMassLevel.numberOfTests})");
 		}
 		else
 		{
@@ -434,6 +433,8 @@ public class ActivitySevenManager : ActivityManager
 
 	private void UpdateCenterOfMassViewState()
 	{
+		missionObjectiveDisplayUI.UpdateMissionObjectiveText(0, $"Retrieve the power cube by computing for its center of mass on the Center of Mass Terminal ({currentCenterOfMassLevel.numberOfTests - currentNumCenterOfMassTests}/{currentCenterOfMassLevel.numberOfTests})");
+
 		if (currentNumCenterOfMassTests > 0)
 		{
 			GenerateMassCoordinatePairs(currentCenterOfMassLevel);
@@ -577,8 +578,6 @@ public class ActivitySevenManager : ActivityManager
 				momentumImpulseForceSubmissionStatusDisplay.SetSubmissionStatus(true, displayText);
 
 				momentumImpulseForceView.UpdateCalibrationTestTextDisplay(currentMomentumImpulseForceLevel.numberOfTests - currentNumMomentumImpulseForceTests, currentMomentumImpulseForceLevel.numberOfTests);
-
-				missionObjectiveDisplayUI.UpdateMissionObjectiveText(1, $"Unlock the impulse momentum mechanism of the door containing the ships' data module on the Impulse-Momentum Terminal ({currentMomentumImpulseForceLevel.numberOfTests - currentNumMomentumImpulseForceTests}/{currentMomentumImpulseForceLevel.numberOfTests})");
 			}
 			else
 			{
@@ -623,7 +622,9 @@ public class ActivitySevenManager : ActivityManager
 
 	private void UpdateMomentumImpulseForceViewState()
 	{
-		if (currentNumCenterOfMassTests > 0)
+		missionObjectiveDisplayUI.UpdateMissionObjectiveText(1, $"Unlock the impulse momentum mechanism of the door containing the ships' data module on the Impulse-Momentum Terminal ({currentMomentumImpulseForceLevel.numberOfTests - currentNumMomentumImpulseForceTests}/{currentMomentumImpulseForceLevel.numberOfTests})");
+
+		if (currentNumMomentumImpulseForceTests > 0)
 		{
 			GenerateMomentumImpulseForceGivenData(currentMomentumImpulseForceLevel);
 			momentumImpulseForceView.SetupMomentumImpulseForceView(momentumImpulseForceGivenData);
@@ -739,8 +740,6 @@ public class ActivitySevenManager : ActivityManager
 			elasticInelasticCollisionSubmissionStatusDisplay.SetSubmissionStatus(true, displayText);
 
 			elasticInelasticCollisionView.UpdateCalibrationTestTextDisplay(currentElasticInelasticCollisionLevel.numberOfTests - currentNumElasticInelasticCollisionTests, currentElasticInelasticCollisionLevel.numberOfTests);
-
-			missionObjectiveDisplayUI.UpdateMissionObjectiveText(2, $"Release the ships' data module from its container by overriding the Collisions Terminal ({currentElasticInelasticCollisionLevel.numberOfTests - currentNumElasticInelasticCollisionTests}/{currentElasticInelasticCollisionLevel.numberOfTests})");
 		}
 		else
 		{
@@ -756,7 +755,9 @@ public class ActivitySevenManager : ActivityManager
 
 	private void UpdateElasticInelasticCollisionViewState()
 	{
-		if (currentNumCenterOfMassTests > 0)
+		missionObjectiveDisplayUI.UpdateMissionObjectiveText(2, $"Release the ships' data module from its container by overriding the Collisions Terminal ({currentElasticInelasticCollisionLevel.numberOfTests - currentNumElasticInelasticCollisionTests}/{currentElasticInelasticCollisionLevel.numberOfTests})");
+
+		if (currentNumElasticInelasticCollisionTests > 0)
 		{
 			GenerateElasticInelasticCollisionData(currentElasticInelasticCollisionLevel);
 			elasticInelasticCollisionView.SetupElasicInelasticCollisionView(elasticInelasticCollisionData);

--- a/Assets/Scripts/Activity 7/Environment/PowerSourceCube.cs
+++ b/Assets/Scripts/Activity 7/Environment/PowerSourceCube.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 public class PowerSourceCube : IInteractableObject
 {
-	public static event Action RetrieveEvent;
+	public event Action RetrieveEvent;
 
 	public float rotationSpeed = 45.0f;
 

--- a/Assets/Scripts/Activity 7/Environment/PowerSourceCubeContainer.cs
+++ b/Assets/Scripts/Activity 7/Environment/PowerSourceCubeContainer.cs
@@ -2,7 +2,7 @@ using System;
 
 public class PowerSourceCubeContainer : IInteractableObject
 {
-	public static event Action InteractEvent;
+	public event Action InteractEvent;
 	public override void Interact()
 	{
 		InteractEvent?.Invoke();

--- a/Assets/Scripts/Activity 7/UI/Center of Mass/CenterOfMassSubmissionStatusDisplay.cs
+++ b/Assets/Scripts/Activity 7/UI/Center of Mass/CenterOfMassSubmissionStatusDisplay.cs
@@ -4,7 +4,7 @@ using UnityEngine.UI;
 
 public class CenterOfMassSubmissionStatusDisplay : SubmissionStatusDisplay
 {
-	public static event Action ProceedEvent;
+	public event Action ProceedEvent;
 
 	[Header("Center Of Mass Info Displays")]
 	[SerializeField] private GameObject centerOfMassXInfo;

--- a/Assets/Scripts/Activity 7/UI/Center of Mass/CenterOfMassView.cs
+++ b/Assets/Scripts/Activity 7/UI/Center of Mass/CenterOfMassView.cs
@@ -51,6 +51,8 @@ public class CenterOfMassAnswerSubmission
 
 public class CenterOfMassView : MonoBehaviour
 {
+	public event Action OpenViewEvent;
+	public event Action QuitViewEvent;
 	public static event Action<CenterOfMassAnswerSubmission> SubmitAnswerEvent;
 
 	[Header("Graph Coordinate Plotter")]
@@ -103,6 +105,11 @@ public class CenterOfMassView : MonoBehaviour
 	[Header("Interactive Buttons")]
     [SerializeField] private Button leftPageButton;
 	[SerializeField] private Button rightPageButton;
+
+	private void OnEnable()
+	{
+		OpenViewEvent?.Invoke();
+	}
 
 	#region View Setup
 	public void SetupCenterOfMassView(List<MassCoordinatePair> massCoordinatePairs)
@@ -213,6 +220,12 @@ public class CenterOfMassView : MonoBehaviour
 	#endregion
 
 	#region Buttons
+	public void OnQuitButtonClick()
+	{
+		gameObject.SetActive(false);
+		QuitViewEvent?.Invoke();
+	}
+
 	public void OnLeftPageButtonClick()
 	{
 		leftPageButton.gameObject.SetActive(false);

--- a/Assets/Scripts/Activity 7/UI/Center of Mass/CenterOfMassView.cs
+++ b/Assets/Scripts/Activity 7/UI/Center of Mass/CenterOfMassView.cs
@@ -53,7 +53,7 @@ public class CenterOfMassView : MonoBehaviour
 {
 	public event Action OpenViewEvent;
 	public event Action QuitViewEvent;
-	public static event Action<CenterOfMassAnswerSubmission> SubmitAnswerEvent;
+	public event Action<CenterOfMassAnswerSubmission> SubmitAnswerEvent;
 
 	[Header("Graph Coordinate Plotter")]
 	[SerializeField] private GraphCoordinatePlotter graphCoordinatePlotter;

--- a/Assets/Scripts/Activity 7/UI/Elastic Inelastic Collision/ElasticInelasticCollisionSubmissionStatusDisplay.cs
+++ b/Assets/Scripts/Activity 7/UI/Elastic Inelastic Collision/ElasticInelasticCollisionSubmissionStatusDisplay.cs
@@ -4,7 +4,7 @@ using UnityEngine.UI;
 
 public class ElasticInelasticCollisionSubmissionStatusDisplay : SubmissionStatusDisplay
 {
-	public static event Action ProceedEvent;
+	public event Action ProceedEvent;
 
 	[Header("Elastic Inelastic Collision Info Displays")]
 	[SerializeField] private GameObject leftPageInfo;

--- a/Assets/Scripts/Activity 7/UI/Elastic Inelastic Collision/ElasticInelasticCollisionView.cs
+++ b/Assets/Scripts/Activity 7/UI/Elastic Inelastic Collision/ElasticInelasticCollisionView.cs
@@ -37,7 +37,7 @@ public class ElasticInelasticCollisionView : MonoBehaviour
 {
 	public event Action OpenViewEvent;
 	public event Action QuitViewEvent;
-	public static event Action<ElasticInelasticCollisionAnswerSubmission> SubmitAnswerEvent;
+	public event Action<ElasticInelasticCollisionAnswerSubmission> SubmitAnswerEvent;
 
 	[Header("Text")]
 	[SerializeField] private TextMeshProUGUI calibrationTestText;

--- a/Assets/Scripts/Activity 7/UI/Elastic Inelastic Collision/ElasticInelasticCollisionView.cs
+++ b/Assets/Scripts/Activity 7/UI/Elastic Inelastic Collision/ElasticInelasticCollisionView.cs
@@ -35,6 +35,8 @@ public class ElasticInelasticCollisionAnswerSubmission
 
 public class ElasticInelasticCollisionView : MonoBehaviour
 {
+	public event Action OpenViewEvent;
+	public event Action QuitViewEvent;
 	public static event Action<ElasticInelasticCollisionAnswerSubmission> SubmitAnswerEvent;
 
 	[Header("Text")]
@@ -99,6 +101,12 @@ public class ElasticInelasticCollisionView : MonoBehaviour
 	[SerializeField] private CollisionTypeButton inelasticButton;
 	[SerializeField] private Button leftPageButton;
 	[SerializeField] private Button rightPageButton;
+
+	private void OnEnable()
+	{
+		OpenViewEvent?.Invoke();
+	}
+
 
 	#region View Setup
 	public void SetupElasicInelasticCollisionView(CollisionData collisionData)
@@ -169,6 +177,12 @@ public class ElasticInelasticCollisionView : MonoBehaviour
 
 		netMomentumCalculations.gameObject.SetActive(true);
 		collisionTypeChoice.gameObject.SetActive(true);
+	}
+
+	public void OnQuitButtonClick()
+	{
+		gameObject.SetActive(false);
+		QuitViewEvent?.Invoke();
 	}
 
 	public void OnSubmitButtonClick()

--- a/Assets/Scripts/Activity 7/UI/Momentum-Impulse Force/MomentumImpulseForceSubmissionStatusDisplay.cs
+++ b/Assets/Scripts/Activity 7/UI/Momentum-Impulse Force/MomentumImpulseForceSubmissionStatusDisplay.cs
@@ -5,7 +5,7 @@ using UnityEngine.UI;
 
 public class MomentumImpulseForceSubmissionStatusDisplay : SubmissionStatusDisplay
 {
-	public static event Action ProceedEvent;
+	public event Action ProceedEvent;
 
 	[Header("Momentum-Impulse Force Status Border Displays")]
 	[SerializeField] private Image momentumStatusBorderDisplay;

--- a/Assets/Scripts/Activity 7/UI/Momentum-Impulse Force/MomentumImpulseForceView.cs
+++ b/Assets/Scripts/Activity 7/UI/Momentum-Impulse Force/MomentumImpulseForceView.cs
@@ -42,6 +42,8 @@ public class MediumHardMomentumImpulseForceAnswerSubmission : MomentumImpulseFor
 
 public class MomentumImpulseForceView : MonoBehaviour
 {
+	public event Action OpenViewEvent;
+	public event Action QuitViewEvent;
 	public static event Action<MomentumImpulseForceAnswerSubmission> SubmitAnswerEvent;
 
 	[Header("Text")]
@@ -80,6 +82,11 @@ public class MomentumImpulseForceView : MonoBehaviour
 	[SerializeField] private TMP_InputField changeInMomentumResultField2; // Medium-hard config (finalMomentum - initialMomentum)
 	[SerializeField] private TMP_InputField impulseResultField;
 	[SerializeField] private TMP_InputField netForceResultField;
+
+	private void OnEnable()
+	{
+		OpenViewEvent?.Invoke();
+	}
 
 	#region View Setup
 
@@ -131,6 +138,12 @@ public class MomentumImpulseForceView : MonoBehaviour
 	}
 
 	#endregion
+
+	public void OnQuitButtonClick()
+	{
+		gameObject.SetActive(false);
+		QuitViewEvent?.Invoke();
+	}
 
 	public void OnSubmitButtonClick()
 	{

--- a/Assets/Scripts/Activity 7/UI/Momentum-Impulse Force/MomentumImpulseForceView.cs
+++ b/Assets/Scripts/Activity 7/UI/Momentum-Impulse Force/MomentumImpulseForceView.cs
@@ -44,7 +44,7 @@ public class MomentumImpulseForceView : MonoBehaviour
 {
 	public event Action OpenViewEvent;
 	public event Action QuitViewEvent;
-	public static event Action<MomentumImpulseForceAnswerSubmission> SubmitAnswerEvent;
+	public event Action<MomentumImpulseForceAnswerSubmission> SubmitAnswerEvent;
 
 	[Header("Text")]
 	[SerializeField] private TextMeshProUGUI calibrationTestText;

--- a/Assets/Scripts/Activity 8/UI/Equilibrium/EquilibriumSubmissionStatusDisplay.cs
+++ b/Assets/Scripts/Activity 8/UI/Equilibrium/EquilibriumSubmissionStatusDisplay.cs
@@ -4,7 +4,7 @@ using System;
 
 public class EquilibriumSubmissionStatusDisplay : SubmissionStatusDisplay
 {
-	public static event Action ProceedEvent;
+	public event Action ProceedEvent;
 
 	[Header("Equilibrium Status Border Displays")]
 	[SerializeField] private Image forceEquilibriumStatusBorderDisplay;

--- a/Assets/Scripts/Activity 8/UI/Equilibrium/EquilibriumView.cs
+++ b/Assets/Scripts/Activity 8/UI/Equilibrium/EquilibriumView.cs
@@ -36,8 +36,9 @@ public class EquilibriumAnswerSubmission
 /// </summary>
 public class EquilibriumView : MonoBehaviour
 {
-	public static event Action QuitViewEvent;
-	public static event Action<EquilibriumAnswerSubmission> SubmitAnswerEvent;
+	public event Action OpenViewEvent;
+	public event Action QuitViewEvent;
+	public event Action<EquilibriumAnswerSubmission> SubmitAnswerEvent;
 
 	[Header("Text")]
 	[SerializeField] private TextMeshProUGUI calibrationTestText;
@@ -88,6 +89,11 @@ public class EquilibriumView : MonoBehaviour
 	[SerializeField] private EquilibriumTypeButton notInEquilibriumButton;
 	[SerializeField] private Button leftPageButton;
 	[SerializeField] private Button rightPageButton;
+
+	private void OnEnable()
+	{
+		OpenViewEvent?.Invoke();
+	}
 
 	/// <summary>
 	/// Setup state of <c>EquilibriumView</c> in displaying given information

--- a/Assets/Scripts/Activity 8/UI/Moment of Inertia/MomentOfInertiaSubmissionStatusDisplay.cs
+++ b/Assets/Scripts/Activity 8/UI/Moment of Inertia/MomentOfInertiaSubmissionStatusDisplay.cs
@@ -7,7 +7,7 @@ using UnityEngine.UI;
 /// </summary>
 public class MomentOfInertiaSubmissionStatusDisplay : SubmissionStatusDisplay
 {
-	public static event Action ProceedEvent;
+	public event Action ProceedEvent;
 
 	[Header("Moment of Inertia Status Border Displays")]
 	[SerializeField] private Image objectTypeStatusBorderDisplay;

--- a/Assets/Scripts/Activity 8/UI/Moment of Inertia/MomentOfInertiaView.cs
+++ b/Assets/Scripts/Activity 8/UI/Moment of Inertia/MomentOfInertiaView.cs
@@ -21,9 +21,10 @@ public class MomentOfInertiaAnswerSubmission
 
 public class MomentOfInertiaView : MonoBehaviour
 {
-	public static event Action QuitViewEvent;
-	public static event Action<MomentOfInertiaAnswerSubmission> SubmitAnswerEvent;
-	public static event Action<InertiaObjectType> UpdateObjectDisplayEvent;
+	public event Action OpenViewEvent;
+	public event Action QuitViewEvent;
+	public event Action<MomentOfInertiaAnswerSubmission> SubmitAnswerEvent;
+	public event Action<InertiaObjectType> UpdateObjectDisplayEvent;
 
 	[Header("Text")]
 	[SerializeField] private TextMeshProUGUI calibrationTestText;
@@ -42,6 +43,11 @@ public class MomentOfInertiaView : MonoBehaviour
 	[SerializeField] private List<MomentOfInertiaFormulaDisplay> formulaDisplays;
 
 	private InertiaObjectType? selectedInertiaObjectType;
+
+	private void OnEnable()
+	{
+		OpenViewEvent?.Invoke();
+	}
 
 	private void Start()
 	{

--- a/Assets/Scripts/Activity 8/UI/Torque/TorqueSubmissionStatusDisplay.cs
+++ b/Assets/Scripts/Activity 8/UI/Torque/TorqueSubmissionStatusDisplay.cs
@@ -7,7 +7,7 @@ using UnityEngine.UI;
 /// </summary>
 public class TorqueSubmissionStatusDisplay : SubmissionStatusDisplay
 {
-	public static event Action ProceedEvent;
+	public event Action ProceedEvent;
 
 	[Header("Torque Status Border Displays")]
 	[SerializeField] private Image torqueMagnitudeStatusBorderDisplay;

--- a/Assets/Scripts/Activity 8/UI/Torque/TorqueView.cs
+++ b/Assets/Scripts/Activity 8/UI/Torque/TorqueView.cs
@@ -25,8 +25,9 @@ public class TorqueAnswerSubmission
 /// </summary>
 public class TorqueView : MonoBehaviour
 {
-	public static event Action QuitViewEvent;
-	public static event Action<List<TorqueAnswerSubmission>> SubmitAnswerEvent;
+	public event Action OpenViewEvent;
+	public event Action QuitViewEvent;
+	public event Action<List<TorqueAnswerSubmission>> SubmitAnswerEvent;
 
 	[Header("Text")]
 	[SerializeField] private TextMeshProUGUI calibrationTestText;
@@ -46,6 +47,11 @@ public class TorqueView : MonoBehaviour
 
 	[Header("Torque Direction Button Containers")]
 	[SerializeField] private List<HorizontalLayoutGroup> torqueDirectionButtonContainers;
+
+	private void OnEnable()
+	{
+		OpenViewEvent?.Invoke();
+	}
 
 	/// <summary>
 	/// Setup state of <c>TorqueView</c> in displaying bolt information

--- a/Assets/Scripts/Activity 9/ActivityNineEnvironmentManager.cs
+++ b/Assets/Scripts/Activity 9/ActivityNineEnvironmentManager.cs
@@ -1,14 +1,15 @@
 using UnityEngine;
 
-public class ActivityNineEnvironmentManager : MonoBehaviour
+public class ActivityNineEnvironmentManager : ActivityEnvironmentManager
 {
-	[Header("Input Reader")]
-	[SerializeField] private InputReader inputReader;
+	[Header("Activity Manager")]
+	[SerializeField] private ActivityNineManager activityNineManager;
 
+	[Header("Views")]
+	[SerializeField] private GravityView gravityView;
 
-	[Header("Player")]
-	[SerializeField] private GameObject player;
-
+	[Header("Interactable Terminals")]
+	[SerializeField] private InteractableViewOpenerObject gravityControlTerminal;
 
 	[Header("Cameras")]
 	[SerializeField] private Camera planetCamera;
@@ -18,38 +19,24 @@ public class ActivityNineEnvironmentManager : MonoBehaviour
 
 	private void Start()
 	{
-		InteractableControlPanel.SwitchToTargetCameraEvent += SwitchCameraToTargetCamera;
-
-		GravityView.QuitViewEvent += () => SwitchCameraToPlayerCamera(planetCamera);
-		GravityView.UpdateDisplayedOrbittingObjectEvent += ActivateRTCamera;
+		// Gravity Terminal Environment Events
+		gravityView.OpenViewEvent += () => SetGravityTerminalEnvironmentState(true);
+		gravityView.QuitViewEvent += () => SetGravityTerminalEnvironmentState(false);
+		gravityView.UpdateDisplayedOrbittingObjectEvent += ActivateRTCamera;
 	}
 
     private void OnDisable()
     {
-        InteractableControlPanel.SwitchToTargetCameraEvent -= SwitchCameraToTargetCamera;
-
-        GravityView.QuitViewEvent -= () => SwitchCameraToPlayerCamera(planetCamera);
-        GravityView.UpdateDisplayedOrbittingObjectEvent -= ActivateRTCamera;
-    }
-
-    private void SwitchCameraToTargetCamera(Camera targetCamera)
-	{
-		if (player != null && targetCamera != null)
-		{
-			player.gameObject.SetActive(false);
-			targetCamera.gameObject.SetActive(true);
-		}
-		inputReader.SetUI();
+		gravityView.OpenViewEvent -= () => SetGravityTerminalEnvironmentState(true);
+		gravityView.QuitViewEvent -= () => SetGravityTerminalEnvironmentState(false);
+		gravityView.UpdateDisplayedOrbittingObjectEvent -= ActivateRTCamera;
 	}
 
-	public void SwitchCameraToPlayerCamera(Camera targetCamera)
+	private void SetGravityTerminalEnvironmentState(bool isActive)
 	{
-		if (player != null && targetCamera != null)
-		{
-			player.gameObject.SetActive(true);
-			targetCamera.gameObject.SetActive(false);
-		}
-		inputReader.SetGameplay();
+		SetPlayerActivityState(!isActive);
+		activityNineManager.SetMissionObjectiveDisplay(!isActive);
+		planetCamera.gameObject.SetActive(isActive);
 	}
 
 	private void ActivateRTCamera(OrbittingObjectType orbittingObjectType)

--- a/Assets/Scripts/Activity 9/ActivityNineManager.cs
+++ b/Assets/Scripts/Activity 9/ActivityNineManager.cs
@@ -80,29 +80,30 @@ public class ActivityNineManager : ActivityManager
 	{
 		base.Start();
 
-		// Set level data based from difficulty configuration.
-		ConfigureLevelData(difficultyConfiguration); // IN THE FUTURE, REPLACE WITH WHATEVER SELECTED DIFFICULTY. FOR NOW SET FOR TESTING
+		ConfigureLevelData(difficultyConfiguration);
 
-		// Subscribe to view events
-		GravityView.SubmitAnswerEvent += CheckGravityAnswers;
-		GravitySubmissionStatusDisplay.ProceedEvent += GenerateNewGravityTest;
-		GravitySubmissionStatusDisplay.ProceedEvent += CloseGravityView;
+		SubscribeViewAndDisplayEvents();
 
+		// Initializing given values
 		GenerateGravityGivenData(currentGravityLevel);
 
+		// Setting number of tests
 		currentNumGravityTests = currentGravityLevel.numberOfTests;
 
+		// Setting up views
 		gravityView.SetupGravityView(gravityGivenData);
 		gravityView.UpdateCalibrationTestTextDisplay(0, currentGravityLevel.numberOfTests);
+
+		// Update mission objective display
+		missionObjectiveDisplayUI.UpdateMissionObjectiveText(0, $"Calculate the Gravitational Potential Energy and Gravitational Force of the satellite on the Gravity Control Terminal ({currentGravityLevel.numberOfTests - currentNumGravityTests}/{currentGravityLevel.numberOfTests})");
 
 		inputReader.SetGameplay();
 	}
 
     private void OnDisable()
     {
-        GravityView.SubmitAnswerEvent -= CheckGravityAnswers;
-        GravitySubmissionStatusDisplay.ProceedEvent -= GenerateNewGravityTest;
-        GravitySubmissionStatusDisplay.ProceedEvent -= CloseGravityView;
+        gravityView.SubmitAnswerEvent -= CheckGravityAnswers;
+        gravitySubmissionStatusDisplay.ProceedEvent -= UpdateGravityViewState;
     }
 
     private void Update()
@@ -131,6 +132,13 @@ public class ActivityNineManager : ActivityManager
 				currentGravityLevel = gravityLevelThree;
 				break;
 		}
+	}
+
+	private void SubscribeViewAndDisplayEvents()
+	{
+		// Gravity Sub Activity Related Events
+		gravityView.SubmitAnswerEvent += CheckGravityAnswers;
+		gravitySubmissionStatusDisplay.ProceedEvent += UpdateGravityViewState;
 	}
 
 	private void GenerateGravityGivenData(GravitySubActivitySO gravitySubActivitySO)
@@ -232,26 +240,28 @@ public class ActivityNineManager : ActivityManager
 		gravitySubmissionStatusDisplay.gameObject.SetActive(true);
 	}
 
-	private void GenerateNewGravityTest()
+	private void UpdateGravityViewState()
 	{
+		missionObjectiveDisplayUI.UpdateMissionObjectiveText(0, $"Calculate the Gravitational Potential Energy and Gravitational Force of the satellite on the Gravity Control Terminal ({currentGravityLevel.numberOfTests - currentNumGravityTests}/{currentGravityLevel.numberOfTests})");
+
 		if (currentNumGravityTests > 0)
 		{
 			GenerateGravityGivenData(currentGravityLevel);
 			gravityView.SetupGravityView(gravityGivenData);
 		}
-	}
-
-	private void CloseGravityView()
-	{
-		if (currentNumGravityTests <= 0)
+		else
 		{
 			gravityView.gameObject.SetActive(false);
 			DisplayPerformanceView();
+			missionObjectiveDisplayUI.ClearMissionObjective(0);
 		}
 	}
 
 	public override void DisplayPerformanceView()
 	{
+		missionObjectiveDisplayUI.ClearMissionObjective(1);
+		SetMissionObjectiveDisplay(false);
+
 		inputReader.SetUI();
 		performanceView.gameObject.SetActive(true);
 

--- a/Assets/Scripts/Activity 9/UI/GravitySubmissionStatusDisplay.cs
+++ b/Assets/Scripts/Activity 9/UI/GravitySubmissionStatusDisplay.cs
@@ -4,7 +4,7 @@ using UnityEngine.UI;
 
 public class GravitySubmissionStatusDisplay : SubmissionStatusDisplay
 {
-	public static event Action ProceedEvent;
+	public event Action ProceedEvent;
 
 	[Header("Gravity Status Border Displays")]
 	[SerializeField] private Image gravitationalForceStatusBorderDisplay;

--- a/Assets/Scripts/Activity 9/UI/GravityView.cs
+++ b/Assets/Scripts/Activity 9/UI/GravityView.cs
@@ -20,9 +20,10 @@ public class GravityAnswerSubmission
 
 public class GravityView : MonoBehaviour
 {
-	public static event Action QuitViewEvent;
-	public static event Action<GravityAnswerSubmission> SubmitAnswerEvent;
-	public static event Action<OrbittingObjectType> UpdateDisplayedOrbittingObjectEvent;
+	public event Action OpenViewEvent;
+	public event Action QuitViewEvent;
+	public event Action<GravityAnswerSubmission> SubmitAnswerEvent;
+	public event Action<OrbittingObjectType> UpdateDisplayedOrbittingObjectEvent;
 
 	[Header("Text")]
 	[SerializeField] private TextMeshProUGUI calibrationTestText;
@@ -48,6 +49,11 @@ public class GravityView : MonoBehaviour
 	[Header("Interactive Buttons")]
 	[SerializeField] private Button leftPageButton;
 	[SerializeField] private Button rightPageButton;
+
+	private void OnEnable()
+	{
+		OpenViewEvent?.Invoke();
+	}
 
 	public void SetupGravityView(GravityData data)
 	{


### PR DESCRIPTION
The PR adds the **mission objective display UI** for activities 5 - 9 of the game.
The following are screenshots of the player's screen with the mission objective display for each activity:

### Activity 5
![image](https://github.com/user-attachments/assets/5773b6b1-571f-49af-9a0e-7d8532f2bf8c)

### Activity 6
![image](https://github.com/user-attachments/assets/09e4f40a-8a8d-495d-80af-3b00cb963a9c)

### Activity 7
![image](https://github.com/user-attachments/assets/c8592bbc-5ee3-4152-999d-50e98824ae84)

### Activity 8
![image](https://github.com/user-attachments/assets/5ad06130-030b-4e78-a463-08950e277c3f)

### Activity 9
![image](https://github.com/user-attachments/assets/9dbe5ee6-0fd6-4f21-b48c-d37c96506f78)
