### PR TITLE
feat: store activity gameplay metrics to database

### DIFF
--- a/Assets/Scripts/Activity 1/ActivityOneManager.cs
+++ b/Assets/Scripts/Activity 1/ActivityOneManager.cs
@@ -71,6 +71,9 @@ public class ActivityOneManager : ActivityManager
 	private int numIncorrectErrorsSubmission;
 	private int numCorrectErrorsSubmission;
 
+	// Variable for tracking if activity performance is displayed
+	private bool hasDisplayedPerformance = false;
+
 	protected override void Start()
 	{
 		base.Start();
@@ -98,7 +101,10 @@ public class ActivityOneManager : ActivityManager
 		if (isVarianceViewActive && !isVarianceSubActivityFinished) varianceGameplayDuration += Time.deltaTime;
 		if (isAPViewActive && !isAPSubActivityFinished) APGameplayDuration += Time.deltaTime;
 		if (isErrorsViewActive && !isErrorsSubActivityFinished) errorsGameplayDuration += Time.deltaTime;
-		if (isSNSubActivityFinished && isVarianceSubActivityFinished && isAPSubActivityFinished && isErrorsSubActivityFinished) DisplayPerformanceView();
+		if (isSNSubActivityFinished && isVarianceSubActivityFinished && isAPSubActivityFinished && isErrorsSubActivityFinished)
+		{
+			DisplayPerformanceView();
+		}
 	}
 
 	private void ConfigureLevelData(Difficulty difficulty)
@@ -347,8 +353,83 @@ public class ActivityOneManager : ActivityManager
 	}
 	#endregion
 
+	private void AddAttemptRecord()
+	{
+		Dictionary<string, object> scientificNotationResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isSNSubActivityFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectSNSubmission) },
+					{ "durationInSec", new FirestoreField((int)SNGameplayDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> varianceResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isVarianceSubActivityFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectVarianceSubmission) },
+					{ "durationInSec", new FirestoreField((int)varianceGameplayDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> accuracyPrecisionResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isAPSubActivityFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectAPSubmission) },
+					{ "durationInSec", new FirestoreField((int)APGameplayDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> errorsResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isErrorsSubActivityFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectErrorsSubmission) },
+					{ "durationInSec", new FirestoreField((int)errorsGameplayDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> results = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, object>
+				{
+					{ "scientificNotation", new FirestoreField(scientificNotationResults)},
+					{ "variance", new FirestoreField(varianceResults)},
+					{ "accuracyPrecision", new FirestoreField(accuracyPrecisionResults)},
+					{ "errors", new FirestoreField(errorsResults)},
+				}
+			}
+		};
+
+		Dictionary<string, FirestoreField> fields = new Dictionary<string, FirestoreField>
+		{
+			{ "dateAttempted", new FirestoreField(DateTime.UtcNow) },
+			{ "difficulty", new FirestoreField($"{difficultyConfiguration}") },
+			{ "results", new FirestoreField(results) },
+			{ "status", new FirestoreField(isSNSubActivityFinished && isVarianceSubActivityFinished && isAPSubActivityFinished && isErrorsSubActivityFinished) },
+			{ "studentId", new FirestoreField(UserManager.Instance.CurrentUser.localId) },
+			{ "totalDurationInSec", new FirestoreField((int)(SNGameplayDuration + varianceGameplayDuration + APGameplayDuration + errorsGameplayDuration)) }
+		};
+
+		StartCoroutine(UserManager.Instance.CreateAttemptDocument(fields, "activityOneAttempts"));
+	}
+
 	public override void DisplayPerformanceView()
 	{
+		if (hasDisplayedPerformance) return;
+
+		AddAttemptRecord();
+
 		inputReader.SetUI();
 		performanceView.gameObject.SetActive(true);
 
@@ -413,6 +494,8 @@ public class ActivityOneManager : ActivityManager
 				averageScoreThreshold: 2
 				)
 			);
+
+		hasDisplayedPerformance = true;
 	}
 
 	protected override void HandleGameplayPause()

--- a/Assets/Scripts/Activity 1/ActivityOneManager.cs
+++ b/Assets/Scripts/Activity 1/ActivityOneManager.cs
@@ -71,9 +71,6 @@ public class ActivityOneManager : ActivityManager
 	private int numIncorrectErrorsSubmission;
 	private int numCorrectErrorsSubmission;
 
-	// Variable for tracking if activity performance is displayed
-	private bool hasDisplayedPerformance = false;
-
 	protected override void Start()
 	{
 		base.Start();
@@ -353,7 +350,7 @@ public class ActivityOneManager : ActivityManager
 	}
 	#endregion
 
-	private void AddAttemptRecord()
+	protected override void AddAttemptRecord()
 	{
 		Dictionary<string, object> scientificNotationResults = new Dictionary<string, object>
 		{
@@ -416,7 +413,7 @@ public class ActivityOneManager : ActivityManager
 			{ "dateAttempted", new FirestoreField(DateTime.UtcNow) },
 			{ "difficulty", new FirestoreField($"{difficultyConfiguration}") },
 			{ "results", new FirestoreField(results) },
-			{ "status", new FirestoreField(isSNSubActivityFinished && isVarianceSubActivityFinished && isAPSubActivityFinished && isErrorsSubActivityFinished) },
+			{ "isAccomplished", new FirestoreField(isSNSubActivityFinished && isVarianceSubActivityFinished && isAPSubActivityFinished && isErrorsSubActivityFinished) },
 			{ "studentId", new FirestoreField(UserManager.Instance.CurrentUser.localId) },
 			{ "totalDurationInSec", new FirestoreField((int)(SNGameplayDuration + varianceGameplayDuration + APGameplayDuration + errorsGameplayDuration)) }
 		};
@@ -426,9 +423,7 @@ public class ActivityOneManager : ActivityManager
 
 	public override void DisplayPerformanceView()
 	{
-		if (hasDisplayedPerformance) return;
-
-		AddAttemptRecord();
+		base.DisplayPerformanceView();
 
 		inputReader.SetUI();
 		performanceView.gameObject.SetActive(true);
@@ -494,8 +489,6 @@ public class ActivityOneManager : ActivityManager
 				averageScoreThreshold: 2
 				)
 			);
-
-		hasDisplayedPerformance = true;
 	}
 
 	protected override void HandleGameplayPause()

--- a/Assets/Scripts/Activity 2/ActivityTwoManager.cs
+++ b/Assets/Scripts/Activity 2/ActivityTwoManager.cs
@@ -309,8 +309,69 @@ public class ActivityTwoManager : ActivityManager
 	}
 	#endregion
 
+	protected override void AddAttemptRecord()
+	{
+		Dictionary<string, object> quantitiesResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isQuantitiesSubActivityFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectQuantitiesSubmission) },
+					{ "durationInSec", new FirestoreField((int)quantitiesGameplayDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> cartesianComponentsResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isCartesianComponentsSubActivityFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectCartesianComponentsSubmission) },
+					{ "durationInSec", new FirestoreField((int)cartesianComponentsGameplayDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> vectorAdditionResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isVectorAdditionSubActivityFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectVectorAdditionSubmission) },
+					{ "durationInSec", new FirestoreField((int)vectorAdditionGameplayDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> results = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, object>
+				{
+					{ "quantities", new FirestoreField(quantitiesResults)},
+					{ "cartesianComponents", new FirestoreField(cartesianComponentsResults)},
+					{ "vectorAddition", new FirestoreField(vectorAdditionResults)},
+				}
+			}
+		};
+
+		Dictionary<string, FirestoreField> fields = new Dictionary<string, FirestoreField>
+		{
+			{ "dateAttempted", new FirestoreField(DateTime.UtcNow) },
+			{ "difficulty", new FirestoreField($"{difficultyConfiguration}") },
+			{ "results", new FirestoreField(results) },
+			{ "isAccomplished", new FirestoreField(isQuantitiesSubActivityFinished && isCartesianComponentsSubActivityFinished && isVectorAdditionSubActivityFinished) },
+			{ "studentId", new FirestoreField(UserManager.Instance.CurrentUser.localId) },
+			{ "totalDurationInSec", new FirestoreField((int)(quantitiesGameplayDuration + cartesianComponentsGameplayDuration + vectorAdditionGameplayDuration)) }
+		};
+
+		StartCoroutine(UserManager.Instance.CreateAttemptDocument(fields, "activityTwoAttempts"));
+	}
+
 	public override void DisplayPerformanceView()
 	{
+		base.DisplayPerformanceView();
+
 		inputReader.SetUI();
 		performanceView.gameObject.SetActive(true);
 

--- a/Assets/Scripts/Activity 3/ActivityThreeManager.cs
+++ b/Assets/Scripts/Activity 3/ActivityThreeManager.cs
@@ -380,8 +380,59 @@ public class ActivityThreeManager : ActivityManager
 	}
 	#endregion
 
+	protected override void AddAttemptRecord()
+	{
+		Dictionary<string, object> graphsResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isGraphsSubActivityFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectGraphsSubmission) },
+					{ "durationInSec", new FirestoreField((int)graphsGameplayDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> kinematics1DResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccelerationAccomplished", new FirestoreField(isAccelerationCalcFinished) },
+					{ "accelerationMistakes", new FirestoreField(numIncorrectAccelerationSubmission) },
+					{ "isTotalDepthAccomplished", new FirestoreField(isTotalDepthCalcFinished) },
+					{ "totalDepthMistakes", new FirestoreField(numIncorrectTotalDepthSubmission) },
+					{ "durationInSec", new FirestoreField((int)kinematics1DGameplayDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> results = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, object>
+				{
+					{ "graphs", new FirestoreField(graphsResults)},
+					{ "1DKinematics", new FirestoreField(kinematics1DResults)},
+				}
+			}
+		};
+
+		Dictionary<string, FirestoreField> fields = new Dictionary<string, FirestoreField>
+		{
+			{ "dateAttempted", new FirestoreField(DateTime.UtcNow) },
+			{ "difficulty", new FirestoreField($"{difficultyConfiguration}") },
+			{ "results", new FirestoreField(results) },
+			{ "isAccomplished", new FirestoreField(isGraphsSubActivityFinished && isAccelerationCalcFinished && isTotalDepthCalcFinished) },
+			{ "studentId", new FirestoreField(UserManager.Instance.CurrentUser.localId) },
+			{ "totalDurationInSec", new FirestoreField((int)(graphsGameplayDuration + kinematics1DGameplayDuration)) }
+		};
+
+		StartCoroutine(UserManager.Instance.CreateAttemptDocument(fields, "activityThreeAttempts"));
+	}
+
 	public override void DisplayPerformanceView()
 	{
+		base.DisplayPerformanceView();
+
 		inputReader.SetUI();
 		performanceView.gameObject.SetActive(true);
 

--- a/Assets/Scripts/Activity 4/ActivityFourManager.cs
+++ b/Assets/Scripts/Activity 4/ActivityFourManager.cs
@@ -273,8 +273,57 @@ public class ActivityFourManager : ActivityManager
 	}
 	#endregion
 
+	protected override void AddAttemptRecord()
+	{
+		Dictionary<string, object> projectileMotionResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isProjectileMotionSubActivityFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectProjectileMotionSubmission) },
+					{ "durationInSec", new FirestoreField((int)projectileMotionGameplayDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> circularMotionResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isCircularMotionSubActivityFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectCircularMotionSubmission) },
+					{ "durationInSec", new FirestoreField((int)circularMotionGameplayDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> results = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, object>
+				{
+					{ "projectileMotion", new FirestoreField(projectileMotionResults)},
+					{ "circularMotion", new FirestoreField(circularMotionResults)},
+				}
+			}
+		};
+
+		Dictionary<string, FirestoreField> fields = new Dictionary<string, FirestoreField>
+		{
+			{ "dateAttempted", new FirestoreField(DateTime.UtcNow) },
+			{ "difficulty", new FirestoreField($"{difficultyConfiguration}") },
+			{ "results", new FirestoreField(results) },
+			{ "isAccomplished", new FirestoreField(isProjectileMotionSubActivityFinished && isCircularMotionSubActivityFinished) },
+			{ "studentId", new FirestoreField(UserManager.Instance.CurrentUser.localId) },
+			{ "totalDurationInSec", new FirestoreField((int)(projectileMotionGameplayDuration + circularMotionGameplayDuration)) }
+		};
+
+		StartCoroutine(UserManager.Instance.CreateAttemptDocument(fields, "activityFourAttempts"));
+	}
+
 	public override void DisplayPerformanceView()
 	{
+		base.DisplayPerformanceView();
+
 		inputReader.SetUI();
 		performanceView.gameObject.SetActive(true);
 

--- a/Assets/Scripts/Activity 5/ActivityFiveManager.cs
+++ b/Assets/Scripts/Activity 5/ActivityFiveManager.cs
@@ -551,8 +551,55 @@ public class ActivityFiveManager : ActivityManager
 	}
 	#endregion
 
+	protected override void AddAttemptRecord()
+	{
+		Dictionary<string, object> forceResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isAppleMotionSubActivityFinished && isRockMotionSubActivityFinished && isBoatMotionSubActivityFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectAppleMotionForceSubmission + numIncorrectRockMotionForceSubmission + numIncorrectBoatMotionForceSubmission) },
+				}
+			}
+		};
+
+		Dictionary<string, object> forceDiagramResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isAppleMotionSubActivityFinished && isRockMotionSubActivityFinished && isBoatMotionSubActivityFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectAppleMotionForceDiagramSubmission + numIncorrectRockMotionForceDiagramSubmission + numIncorrectBoatMotionForceDiagramSubmission) },
+				}
+			}
+		};
+
+		Dictionary<string, object> results = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, object>
+				{
+					{ "forceCalculations", new FirestoreField(forceResults)},
+					{ "forceDiagrams", new FirestoreField(forceDiagramResults)},
+				}
+			}
+		};
+
+		Dictionary<string, FirestoreField> fields = new Dictionary<string, FirestoreField>
+		{
+			{ "dateAttempted", new FirestoreField(DateTime.UtcNow) },
+			{ "difficulty", new FirestoreField($"{difficultyConfiguration}") },
+			{ "results", new FirestoreField(results) },
+			{ "isAccomplished", new FirestoreField(isAppleMotionSubActivityFinished && isRockMotionSubActivityFinished && isBoatMotionSubActivityFinished) },
+			{ "studentId", new FirestoreField(UserManager.Instance.CurrentUser.localId) },
+			{ "totalDurationInSec", new FirestoreField((int)(appleMotionGameplayDuartion + rockMotionGameplayDuartion + boatMotionGameplayDuartion)) }
+		};
+
+		StartCoroutine(UserManager.Instance.CreateAttemptDocument(fields, "activityFiveAttempts"));
+	}
+
 	public override void DisplayPerformanceView()
 	{
+		base.DisplayPerformanceView();
+
 		SetMissionObjectiveDisplay(false);
 
 		inputReader.SetUI();

--- a/Assets/Scripts/Activity 6/ActivitySixManager.cs
+++ b/Assets/Scripts/Activity 6/ActivitySixManager.cs
@@ -431,8 +431,69 @@ public class ActivitySixManager : ActivityManager
 	}
 	#endregion
 
+	protected override void AddAttemptRecord()
+	{
+		Dictionary<string, object> dotProductResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isDotProductSubActivityFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectDotProductSubmission) },
+					{ "durationInSec", new FirestoreField((int)dotProductGameplayDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> workResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isWorkSubActivityFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectWorkSubmission) },
+					{ "durationInSec", new FirestoreField((int)workSubActivityGameplayDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> workGraphInterpretationResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isWorkGraphSubActivityFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectWorkGraphSubmission) },
+					{ "durationInSec", new FirestoreField((int)workGraphSubActivityDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> results = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, object>
+				{
+					{ "dotProduct", new FirestoreField(dotProductResults)},
+					{ "work", new FirestoreField(workResults)},
+					{ "workGraphInterpretation", new FirestoreField(workGraphInterpretationResults)},
+				}
+			}
+		};
+
+		Dictionary<string, FirestoreField> fields = new Dictionary<string, FirestoreField>
+		{
+			{ "dateAttempted", new FirestoreField(DateTime.UtcNow) },
+			{ "difficulty", new FirestoreField($"{difficultyConfiguration}") },
+			{ "results", new FirestoreField(results) },
+			{ "isAccomplished", new FirestoreField(isDotProductSubActivityFinished && isWorkSubActivityFinished && isWorkGraphSubActivityFinished) },
+			{ "studentId", new FirestoreField(UserManager.Instance.CurrentUser.localId) },
+			{ "totalDurationInSec", new FirestoreField((int)(dotProductGameplayDuration + workSubActivityGameplayDuration + workGraphSubActivityDuration)) }
+		};
+
+		StartCoroutine(UserManager.Instance.CreateAttemptDocument(fields, "activitySixAttempts"));
+	}
+
 	public override void DisplayPerformanceView()
 	{
+		base.DisplayPerformanceView();
+
 		inputReader.SetUI();
 		performanceView.gameObject.SetActive(true);
 

--- a/Assets/Scripts/Activity 7/ActivitySevenManager.cs
+++ b/Assets/Scripts/Activity 7/ActivitySevenManager.cs
@@ -772,8 +772,69 @@ public class ActivitySevenManager : ActivityManager
 	}
 	#endregion
 
+	protected override void AddAttemptRecord()
+	{
+		Dictionary<string, object> centerOfMassResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isCenterOfMassCalculationFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectCenterOfMassSubmission) },
+					{ "durationInSec", new FirestoreField((int)centerOfMassDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> momentumImpulseForceResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isMomentumImpulseForceCalculationFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectMomentumImpulseForceSubmission) },
+					{ "durationInSec", new FirestoreField((int)momentumImpulseForceDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> elasticInelasticCollisionResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isElasticInelasticCollisionCalculationFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectElasticInelasticCollisionSubmission) },
+					{ "durationInSec", new FirestoreField((int)elasticInelasticCollisionDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> results = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, object>
+				{
+					{ "centerOfMass", new FirestoreField(centerOfMassResults)},
+					{ "momentumImpulseForce", new FirestoreField(momentumImpulseForceResults)},
+					{ "elasticInelasticCollision", new FirestoreField(elasticInelasticCollisionResults)},
+				}
+			}
+		};
+
+		Dictionary<string, FirestoreField> fields = new Dictionary<string, FirestoreField>
+		{
+			{ "dateAttempted", new FirestoreField(DateTime.UtcNow) },
+			{ "difficulty", new FirestoreField($"{difficultyConfiguration}") },
+			{ "results", new FirestoreField(results) },
+			{ "isAccomplished", new FirestoreField(isCenterOfMassCalculationFinished && isMomentumImpulseForceCalculationFinished && isElasticInelasticCollisionCalculationFinished) },
+			{ "studentId", new FirestoreField(UserManager.Instance.CurrentUser.localId) },
+			{ "totalDurationInSec", new FirestoreField((int)(centerOfMassDuration + momentumImpulseForceDuration + elasticInelasticCollisionDuration)) }
+		};
+
+		StartCoroutine(UserManager.Instance.CreateAttemptDocument(fields, "activitySevenAttempts"));
+	}
+
 	public override void DisplayPerformanceView()
 	{
+		base.DisplayPerformanceView();
+
 		missionObjectiveDisplayUI.ClearMissionObjective(3);
 		SetMissionObjectiveDisplay(false);
 

--- a/Assets/Scripts/Activity 8/ActivityEightManager.cs
+++ b/Assets/Scripts/Activity 8/ActivityEightManager.cs
@@ -636,8 +636,69 @@ public class ActivityEightManager : ActivityManager
 	}
 	#endregion
 
+	protected override void AddAttemptRecord()
+	{
+		Dictionary<string, object> momentOfInertiaResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isMomentOfInertiaCalculationFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectMomentOfInertiaSubmission) },
+					{ "durationInSec", new FirestoreField((int)momentOfInertiaDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> torqueResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isTorqueCalculationFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectTorqueSubmission) },
+					{ "durationInSec", new FirestoreField((int)torqueDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> equilibriumResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isEquilibriumCalculationFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectEquilibriumSubmission) },
+					{ "durationInSec", new FirestoreField((int)equilibriumDuration) }
+				}
+			}
+		};
+
+		Dictionary<string, object> results = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, object>
+				{
+					{ "momentOfInertia", new FirestoreField(momentOfInertiaResults)},
+					{ "torque", new FirestoreField(torqueResults)},
+					{ "equilibrium", new FirestoreField(equilibriumResults)},
+				}
+			}
+		};
+
+		Dictionary<string, FirestoreField> fields = new Dictionary<string, FirestoreField>
+		{
+			{ "dateAttempted", new FirestoreField(DateTime.UtcNow) },
+			{ "difficulty", new FirestoreField($"{difficultyConfiguration}") },
+			{ "results", new FirestoreField(results) },
+			{ "isAccomplished", new FirestoreField(isMomentOfInertiaCalculationFinished && isTorqueCalculationFinished && isEquilibriumCalculationFinished) },
+			{ "studentId", new FirestoreField(UserManager.Instance.CurrentUser.localId) },
+			{ "totalDurationInSec", new FirestoreField((int)(momentOfInertiaDuration + torqueDuration + equilibriumDuration)) }
+		};
+
+		StartCoroutine(UserManager.Instance.CreateAttemptDocument(fields, "activityEightAttempts"));
+	}
+
 	public override void DisplayPerformanceView()
 	{
+		base.DisplayPerformanceView();
+
 		missionObjectiveDisplayUI.ClearMissionObjective(3);
 		SetMissionObjectiveDisplay(false);
 

--- a/Assets/Scripts/Activity 9/ActivityNineManager.cs
+++ b/Assets/Scripts/Activity 9/ActivityNineManager.cs
@@ -257,8 +257,45 @@ public class ActivityNineManager : ActivityManager
 		}
 	}
 
+	protected override void AddAttemptRecord()
+	{
+		Dictionary<string, object> gravityResults = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, FirestoreField>
+				{
+					{ "isAccomplished", new FirestoreField(isGravityCalculationFinished) },
+					{ "mistakes", new FirestoreField(numIncorrectGravitySubmission) },
+					{ "durationInSec", new FirestoreField((int)gameplayTime) }
+				}
+			}
+		};
+
+		Dictionary<string, object> results = new Dictionary<string, object>
+		{
+			{ "fields", new Dictionary<string, object>
+				{
+					{ "gravity", new FirestoreField(gravityResults)},
+				}
+			}
+		};
+
+		Dictionary<string, FirestoreField> fields = new Dictionary<string, FirestoreField>
+		{
+			{ "dateAttempted", new FirestoreField(DateTime.UtcNow) },
+			{ "difficulty", new FirestoreField($"{difficultyConfiguration}") },
+			{ "results", new FirestoreField(results) },
+			{ "isAccomplished", new FirestoreField(isGravityCalculationFinished) },
+			{ "studentId", new FirestoreField(UserManager.Instance.CurrentUser.localId) },
+			{ "totalDurationInSec", new FirestoreField((int)gameplayTime)}
+		};
+
+		StartCoroutine(UserManager.Instance.CreateAttemptDocument(fields, "activityNineAttempts"));
+	}
+
 	public override void DisplayPerformanceView()
 	{
+		base.DisplayPerformanceView();
+
 		missionObjectiveDisplayUI.ClearMissionObjective(1);
 		SetMissionObjectiveDisplay(false);
 

--- a/Assets/Scripts/Common Activity Scripts/Managers/ActivityManager.cs
+++ b/Assets/Scripts/Common Activity Scripts/Managers/ActivityManager.cs
@@ -6,6 +6,8 @@ public abstract class ActivityManager : MonoBehaviour
 	[SerializeField] protected ActivityPauseMenuUI activityPauseMenuUI;
 	[SerializeField] protected MissionObjectiveDisplayUI missionObjectiveDisplayUI;
 
+	protected bool hasDisplayedPerformance = false;
+
 	protected virtual void Start()
 	{
 		inputReader.PauseGameplayEvent += HandleGameplayPause;
@@ -35,5 +37,13 @@ public abstract class ActivityManager : MonoBehaviour
 		missionObjectiveDisplayUI.gameObject.SetActive(isActive);
 	}
 
-	public abstract void DisplayPerformanceView();
+	protected abstract void AddAttemptRecord();
+
+	public virtual void DisplayPerformanceView()
+	{
+		if (hasDisplayedPerformance) return;
+		hasDisplayedPerformance = true;
+
+		AddAttemptRecord();
+	}
 }

--- a/Assets/Scripts/User Management/UserManager.cs
+++ b/Assets/Scripts/User Management/UserManager.cs
@@ -26,11 +26,13 @@ public class FirestoreDocument
 [System.Serializable]
 public class FirestoreField
 {
+#nullable enable
 	public string? stringValue;
 	public int? integerValue;
 	public bool? booleanValue;
 	public string? timestampValue;
 	public Dictionary<string, object>? mapValue;
+#nullable disable
 
 	public FirestoreField(string value)
 	{

--- a/Assets/Scripts/User Management/UserManager.cs
+++ b/Assets/Scripts/User Management/UserManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using Newtonsoft.Json;
@@ -25,8 +26,35 @@ public class FirestoreDocument
 [System.Serializable]
 public class FirestoreField
 {
-	public string stringValue;
-	public string timestampValue;
+	public string? stringValue;
+	public int? integerValue;
+	public bool? booleanValue;
+	public string? timestampValue;
+	public Dictionary<string, object>? mapValue;
+
+	public FirestoreField(string value)
+	{
+		stringValue = value;
+	}
+
+	public FirestoreField(int value)
+	{
+		integerValue = value;
+	}
+
+	public FirestoreField(bool value)
+	{
+		booleanValue = value;
+	}
+
+	public FirestoreField(DateTime value)
+	{
+		timestampValue = value.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+	}
+
+	public FirestoreField(Dictionary<string, object> map) => mapValue = map;
+
+	public FirestoreField() { }
 }
 
 public class UserManager : MonoBehaviour
@@ -66,7 +94,7 @@ public class UserManager : MonoBehaviour
 		if (request.result == UnityWebRequest.Result.Success)
 		{
 			CurrentUser = JsonConvert.DeserializeObject<FirebaseAuthResponse>(request.downloadHandler.text);
-			yield return StartCoroutine(GetDocument(CurrentUser.localId, CurrentUser.idToken, (success) =>
+			yield return StartCoroutine(GetDocument(CurrentUser.localId, (success) =>
 			{
 				if (success)
 				{
@@ -89,11 +117,11 @@ public class UserManager : MonoBehaviour
 	}
 
 	// Method to retrieve user document from Firestore
-	public IEnumerator GetDocument(string documentId, string idToken, System.Action<bool> callback)
+	public IEnumerator GetDocument(string documentId, System.Action<bool> callback)
 	{
 		string url = FirestoreBaseURL + documentId;
 		UnityWebRequest request = UnityWebRequest.Get(url);
-		request.SetRequestHeader("Authorization", "Bearer " + idToken);
+		request.SetRequestHeader("Authorization", "Bearer " + CurrentUser.idToken);
 
 		yield return request.SendWebRequest();
 
@@ -133,6 +161,39 @@ public class UserManager : MonoBehaviour
 		else
 		{
 			Debug.LogError("Failed to update document: " + request.downloadHandler.text);
+		}
+	}
+
+	public IEnumerator CreateAttemptDocument(Dictionary<string, FirestoreField> fields, string documentName)
+	{
+		string url = $"https://firestore.googleapis.com/v1/projects/physix-9c8bd/databases/(default)/documents/{documentName}";
+
+		var requestBody = new { fields = fields };
+		string jsonData = JsonConvert.SerializeObject(requestBody, new JsonSerializerSettings
+		{
+			NullValueHandling = NullValueHandling.Ignore
+		}); 
+		Debug.Log("BODY:\n: " + jsonData);
+
+		// Set up UnityWebRequest for POST
+		UnityWebRequest request = new UnityWebRequest(url, "POST");
+		request.uploadHandler = new UploadHandlerRaw(System.Text.Encoding.UTF8.GetBytes(jsonData));
+		request.downloadHandler = new DownloadHandlerBuffer();
+
+		// Set headers
+		request.SetRequestHeader("Content-Type", "application/json");
+		request.SetRequestHeader("Authorization", "Bearer " + CurrentUser.idToken);
+
+		// Send the request and wait for a response
+		yield return request.SendWebRequest();
+
+		if (request.result == UnityWebRequest.Result.Success)
+		{
+			Debug.Log("Document created successfully: " + request.downloadHandler.text);
+		}
+		else
+		{
+			Debug.LogError("Failed to create document: " + request.downloadHandler.text);
 		}
 	}
 }


### PR DESCRIPTION
This PR adds functionality to **store the player's activity gameplay metrics** for the game.
This covers the metrics recorded for activities 1 - 9 of the game.