### PR TITLE
feat: load and save discussion marked pages data, and load user details to database 

### DIFF
--- a/Assets/Scripts/Login/Login Box/LoginBox.cs
+++ b/Assets/Scripts/Login/Login Box/LoginBox.cs
@@ -24,8 +24,6 @@ public class LoginBox : MonoBehaviour
 
     public void ProcessLogin()
     {
-		emailInputField.text = "oliverbrown@gmail.com";
-		passwordInputField.text = "oliverbrown";
 		// Take the value of input fields and feed then verify accoun credentials
 		if (emailInputField.text == "" || passwordInputField.text == "")
 		{

--- a/Assets/Scripts/Login/Login Box/LoginBox.cs
+++ b/Assets/Scripts/Login/Login Box/LoginBox.cs
@@ -24,6 +24,8 @@ public class LoginBox : MonoBehaviour
 
     public void ProcessLogin()
     {
+		emailInputField.text = "oliverbrown@gmail.com";
+		passwordInputField.text = "oliverbrown";
 		// Take the value of input fields and feed then verify accoun credentials
 		if (emailInputField.text == "" || passwordInputField.text == "")
 		{

--- a/Assets/Scripts/Main Menu/MainMenuManager.cs
+++ b/Assets/Scripts/Main Menu/MainMenuManager.cs
@@ -21,12 +21,11 @@ public class MainMenuManager : MonoBehaviour
     private int highestLessonUnlockedDifficulties;
     private void Start()
 	{
-
         // Setup mock user profile and set it up in the title screen
         // Change first name, last name, and section into the loaded user value in the future
-        firstName = "Superman";
-        lastName = "Balatayo";
-        section = "4";
+        firstName = UserManager.Instance.UserData.fields["firstName"].stringValue;
+        lastName = UserManager.Instance.UserData.fields["lastName"].stringValue;
+        section = UserManager.Instance.UserSection.fields["sectionName"].stringValue;
         titleScreen.SetUserProfile(firstName, lastName, section);
 
         // Setup current user's mock highest unlocked lesson and load all unlocked lessons

--- a/Assets/Scripts/Main Menu/MainMenuManager.cs
+++ b/Assets/Scripts/Main Menu/MainMenuManager.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -80,7 +81,7 @@ public class MainMenuManager : MonoBehaviour
         ActivityButton.ActivityClick -= OpenDifficultySelectOverlay;
         ActivityDifficultyButton.DifficultyClick -= OpenActivityWithDifficultyType;
         OverlayCloseButton.OverlayCloseClicked -= CloseDifficultySelectOverlay;
-        LogoutButton.LogoutButtonClick += LogoutUser;
+        LogoutButton.LogoutButtonClick -= LogoutUser;
     }
 
     private void OpenLessonComponentsScreen(int keyValue)
@@ -172,7 +173,13 @@ public class MainMenuManager : MonoBehaviour
 
     private void LogoutUser()
     {
-        // In the future, remove user data and UID session
+        StartCoroutine(LogoutSequence());
+    }
+
+    // Sequence for logging out current user ensuring all fields are set to null
+    private IEnumerator LogoutSequence()
+    {
+        yield return StartCoroutine(UserManager.Instance.LogoutCurrentUser());
         SceneManager.LoadScene("Login");
     }
 }

--- a/Assets/Scripts/Main Menu/UI/Title Screen/TitleScreenButton.cs
+++ b/Assets/Scripts/Main Menu/UI/Title Screen/TitleScreenButton.cs
@@ -45,11 +45,6 @@ public class TitleScreenButton : MonoBehaviour, IPointerEnterHandler, IPointerEx
             screenToDeactivate.gameObject.SetActive(false);
             screenToActivate.gameObject.SetActive(true);
         }
-        else
-        {
-            Debug.Log("Title screen is already deactivated. Maybe there's an error to references.");
-            Debug.Log("Or you may have pressed the Logout Button which does not have a function yet");
-        }
     }
     public void OnPointerEnter(PointerEventData eventData)
     {

--- a/Assets/Scripts/Topic Discussion/TopicDiscussionManager.cs
+++ b/Assets/Scripts/Topic Discussion/TopicDiscussionManager.cs
@@ -1,7 +1,8 @@
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.SceneManagement;
+using System.Collections;
+
 
 public class TopicDiscussionManager : MonoBehaviour
 {
@@ -204,13 +205,11 @@ public class TopicDiscussionManager : MonoBehaviour
     #region Discussion Scene Close Related Buttons
     private void HandleBackToMainMenuClick()
     {
-        SaveReadPagesDataToDB(_topicDiscussionNumber);
+        StartCoroutine(BackToMenuSequence());
     }
     private void HandleStartActivityClick()
     {
-        //// Save read pages data and load specified activity scene
-        //discussionPagesDisplay.RecordReadPagesData();
-        //sceneNavigationDisplay.LoadActivity(_topicDiscussionNumber);
+        StartCoroutine(StartActivitySequence());
     }
     private void HandleBackToGameClick()
     {
@@ -218,6 +217,18 @@ public class TopicDiscussionManager : MonoBehaviour
         //discussionPagesDisplay.RecordReadPagesData();
         //sceneNavigationDisplay.CloseCurrentDiscussion(_topicDiscussionNumber);
 
+    }
+    // Used for handling the sequences of going back to main menu while also saving current pages data
+    private IEnumerator BackToMenuSequence()
+    {
+        yield return StartCoroutine(SaveReadPagesDataToDB());
+        sceneNavigationDisplay.LoadMainMenu();
+    }
+    // Used for handling the sequences of starting the activity while also saving current pages data
+    private IEnumerator StartActivitySequence()
+    {
+        yield return StartCoroutine(SaveReadPagesDataToDB());
+        sceneNavigationDisplay.LoadActivity(_topicDiscussionNumber);
     }
     #endregion
 
@@ -331,7 +342,7 @@ public class TopicDiscussionManager : MonoBehaviour
     }
 
     // Save new read pages data to database
-    private void SaveReadPagesDataToDB(int topicDiscussionNumber)
+    private IEnumerator SaveReadPagesDataToDB()
     {
         // Create generalize data to be used in all cases
         Dictionary<string, List<int>> recordedMarkedPages = discussionPagesDisplay.RecordReadPagesData();
@@ -342,7 +353,7 @@ public class TopicDiscussionManager : MonoBehaviour
 
         string currentUserLocalID = UserManager.Instance.CurrentUser.localId;
 
-        switch (topicDiscussionNumber)
+        switch (_topicDiscussionNumber)
         {
             case 1: // 5 Sectors
                 // Create the appropriate amount of lists needed for a discussion's sector count
@@ -357,7 +368,7 @@ public class TopicDiscussionManager : MonoBehaviour
 
                 // Process and create the updated fields dictionary
                 updatedFields = CreateUpdatedFieldsDictionary(sectors, recordedMarkedPages);
-                StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionOnePageProgress", currentUserLocalID, OnPagesSaveResult));
+                yield return StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionOnePageProgress", currentUserLocalID));
                 break;
 
             case 2: // 4 Sectors
@@ -372,7 +383,7 @@ public class TopicDiscussionManager : MonoBehaviour
 
                 // Process and create the updated fields dictionary
                 updatedFields = CreateUpdatedFieldsDictionary(sectors, recordedMarkedPages);
-                StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionTwoPageProgress", currentUserLocalID, OnPagesSaveResult));
+                yield return StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionTwoPageProgress", currentUserLocalID));
                 break;
 
             case 3: // 3 Sectors
@@ -386,7 +397,7 @@ public class TopicDiscussionManager : MonoBehaviour
 
                 // Process and create the updated fields dictionary
                 updatedFields = CreateUpdatedFieldsDictionary(sectors, recordedMarkedPages);
-                StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionThreePageProgress", currentUserLocalID, OnPagesSaveResult));
+                yield return StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionThreePageProgress", currentUserLocalID));
                 break;
 
             case 4: // 3 Sectors
@@ -400,7 +411,7 @@ public class TopicDiscussionManager : MonoBehaviour
 
                 // Process and create the updated fields dictionary
                 updatedFields = CreateUpdatedFieldsDictionary(sectors, recordedMarkedPages);
-                StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionFourPageProgress", currentUserLocalID, OnPagesSaveResult));
+                yield return StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionFourPageProgress", currentUserLocalID));
                 break;
 
             case 5: // 3 Sectors
@@ -414,7 +425,7 @@ public class TopicDiscussionManager : MonoBehaviour
 
                 // Process and create the updated fields dictionary
                 updatedFields = CreateUpdatedFieldsDictionary(sectors, recordedMarkedPages);
-                StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionFivePageProgress", currentUserLocalID, OnPagesSaveResult));
+                yield return StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionFivePageProgress", currentUserLocalID));
                 break;
 
             case 6: // 4 Sectors
@@ -429,7 +440,7 @@ public class TopicDiscussionManager : MonoBehaviour
 
                 // Process and create the updated fields dictionary
                 updatedFields = CreateUpdatedFieldsDictionary(sectors, recordedMarkedPages);
-                StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionSixPageProgress", currentUserLocalID, OnPagesSaveResult));
+                yield return StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionSixPageProgress", currentUserLocalID));
                 break;
 
             case 7: // 4 Sectors
@@ -444,7 +455,7 @@ public class TopicDiscussionManager : MonoBehaviour
 
                 // Process and create the updated fields dictionary
                 updatedFields = CreateUpdatedFieldsDictionary(sectors, recordedMarkedPages);
-                StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionSevenPageProgress", currentUserLocalID, OnPagesSaveResult));
+                yield return StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionSevenPageProgress", currentUserLocalID));
                 break;
 
             case 8: // 4 Sectors
@@ -459,7 +470,7 @@ public class TopicDiscussionManager : MonoBehaviour
 
                 // Process and create the updated fields dictionary
                 updatedFields = CreateUpdatedFieldsDictionary(sectors, recordedMarkedPages);
-                StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionEigthPageProgress", currentUserLocalID, OnPagesSaveResult));
+                yield return StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionEightPageProgress", currentUserLocalID));
                 break;
 
             case 9: // 2 Sectors
@@ -472,12 +483,11 @@ public class TopicDiscussionManager : MonoBehaviour
 
                 // Process and create the updated fields dictionary
                 updatedFields = CreateUpdatedFieldsDictionary(sectors, recordedMarkedPages);
-                StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionNinePageProgress", currentUserLocalID, OnPagesSaveResult));
+                yield return StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionNinePageProgress", currentUserLocalID));
                 break;
         }
     }
 
-    // Callbacks
     // Callback for GetReadPagesDataFromDB()
     private void OnPagesGetResult(bool success)
     {
@@ -541,24 +551,149 @@ public class TopicDiscussionManager : MonoBehaviour
         }
         else
         {
-            Debug.LogError("Marked Pages Data was not saved");
-        }
-    }
-    // Callback for SaveReadPagesDataToDB
-    private void OnPagesSaveResult(bool success)
-    {
-        if (success)
-        {
-            SceneManager.LoadScene("Main Menu");
-        }
-        else
-        {
-            Debug.LogError("Marked Pages Data was not saved");
+            List<List<object>> sectors;
+            Dictionary<string, FirestoreField> updatedFields;
+
+            string currentUserLocalID = UserManager.Instance.CurrentUser.localId;
+
+            switch (_topicDiscussionNumber)
+            {
+                case 1: // 5 Sectors
+                        // Create the appropriate amount of lists needed for a discussion's sector count
+                    sectors = new List<List<object>>()
+                {
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                };
+
+                    // Process and create the updated fields dictionary
+                    updatedFields = CreateBlankFieldsDictionary(sectors);
+                    StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionOnePageProgress", currentUserLocalID));
+                    break;
+
+                case 2: // 4 Sectors
+                        // Create the appropriate amount of lists needed for a discussion's sector count
+                    sectors = new List<List<object>>()
+                {
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                };
+
+                    // Process and create the updated fields dictionary
+                    updatedFields = CreateBlankFieldsDictionary(sectors);
+                    StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionTwoPageProgress", currentUserLocalID));
+                    break;
+
+                case 3: // 3 Sectors
+                        // Create the appropriate amount of lists needed for a discussion's sector count
+                    sectors = new List<List<object>>()
+                {
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                };
+
+                    // Process and create the updated fields dictionary
+                    updatedFields = CreateBlankFieldsDictionary(sectors);
+                    StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionThreePageProgress", currentUserLocalID));
+                    break;
+
+                case 4: // 3 Sectors
+                        // Create the appropriate amount of lists needed for a discussion's sector count
+                    sectors = new List<List<object>>()
+                {
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                };
+
+                    // Process and create the updated fields dictionary
+                    updatedFields = CreateBlankFieldsDictionary(sectors);
+                    StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionFourPageProgress", currentUserLocalID));
+                    break;
+
+                case 5: // 3 Sectors
+                        // Create the appropriate amount of lists needed for a discussion's sector count
+                    sectors = new List<List<object>>()
+                {
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                };
+
+                    // Process and create the updated fields dictionary
+                    updatedFields = CreateBlankFieldsDictionary(sectors);
+                    StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionFivePageProgress", currentUserLocalID));
+                    break;
+
+                case 6: // 4 Sectors
+                        // Create the appropriate amount of lists needed for a discussion's sector count
+                    sectors = new List<List<object>>()
+                {
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                };
+
+                    // Process and create the updated fields dictionary
+                    updatedFields = CreateBlankFieldsDictionary(sectors);
+                    StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionSixPageProgress", currentUserLocalID));
+                    break;
+
+                case 7: // 4 Sectors
+                        // Create the appropriate amount of lists needed for a discussion's sector count
+                    sectors = new List<List<object>>()
+                {
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                };
+
+                    // Process and create the updated fields dictionary
+                    updatedFields = CreateBlankFieldsDictionary(sectors);
+                    StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionSevenPageProgress", currentUserLocalID));
+                    break;
+
+                case 8: // 4 Sectors
+                        // Create the appropriate amount of lists needed for a discussion's sector count
+                    sectors = new List<List<object>>()
+                {
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                };
+
+                    // Process and create the updated fields dictionary
+                    updatedFields = CreateBlankFieldsDictionary(sectors);
+                    StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionEightPageProgress", currentUserLocalID));
+                    break;
+
+                case 9: // 2 Sectors
+                        // Create the appropriate amount of lists needed for a discussion's sector count
+                    sectors = new List<List<object>>()
+                {
+                    new List<object>(),
+                    new List<object>(),
+                };
+
+                    // Process and create the updated fields dictionary
+                    updatedFields = CreateBlankFieldsDictionary(sectors);
+                    StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionNinePageProgress", currentUserLocalID));
+                    break;
+            }
+            GetReadPagesDataFromDB();
         }
     }
 
-    // Helper Functions
-    // Helper function of GetReadPagesDataFromDB()
+    // Helper function for creating the dictionary that will be used to load all pages data colors and text
     private Dictionary<string, List<int>> ParseDocumentToDict(Dictionary<string, object> markedPages)
     {
         Dictionary<string, List<int>> sectorArrayPairs = new Dictionary<string, List<int>>();
@@ -593,7 +728,7 @@ public class TopicDiscussionManager : MonoBehaviour
         }
         return sectorArrayPairs;
     }
-    // Helper function of SaveReadPagesDataToDB()
+    // Helper function for creating the current updates pages data to be saved in the database
     private Dictionary<string, FirestoreField> CreateUpdatedFieldsDictionary(List<List<object>> sectors, Dictionary<string, List<int>> recordedMarkedPages)
     {
         // Add the values of each array from the recorded marked pages as FirestoreField data
@@ -626,5 +761,29 @@ public class TopicDiscussionManager : MonoBehaviour
 
         return updatedFields;
     }
-#endregion
+    // Helper function for creating new blank pages data if current user pages data not found
+    private Dictionary<string, FirestoreField> CreateBlankFieldsDictionary(List<List<object>> sectors)
+    {
+        // Create the sectorListPairs dictionary to be used in the markedPages Dictionary
+        Dictionary<string, object> sectorListPairs = new Dictionary<string, object>();
+
+        // Add all sector key and array values that were converted to FirestoreField data
+        for (int i = 0; i < sectors.Count; i++)
+        {
+            sectorListPairs[$"sector{i + 1}"] = new { arrayValue = new { values = sectors[i] } };
+        }
+
+        Dictionary<string, object> markedPages = new Dictionary<string, object>()
+        {
+            {"fields", sectorListPairs}
+        };
+
+        Dictionary<string, FirestoreField> updatedFields = new Dictionary<string, FirestoreField>()
+        {
+            {"markedPages", new FirestoreField(markedPages) }
+        };
+
+        return updatedFields;
+    }
+    #endregion
 }

--- a/Assets/Scripts/Topic Discussion/TopicDiscussionManager.cs
+++ b/Assets/Scripts/Topic Discussion/TopicDiscussionManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class TopicDiscussionManager : MonoBehaviour
 {
@@ -47,8 +48,10 @@ public class TopicDiscussionManager : MonoBehaviour
         // Test data for topic discussion 9
         _readPagesMapData = new Dictionary<string, List<int>>()
         {
-            { "sector1", new List<int> { 0, 1, 2, 3, 4} },
+            { "sector1", new List<int> { 0, 1} },
             { "sector2", new List<int> { 0 } },
+            { "sector3", new List<int> { } },
+            { "sector4", new List<int> { } },
         };
 
         // Load read pages data into the sub topics list of discussion pages display
@@ -100,6 +103,7 @@ public class TopicDiscussionManager : MonoBehaviour
         DiscussionBackToActivityButton.BackToActivityClickEvent -= HandleBackToGameClick;
     }
 
+#region Function for Event Handling
     private void HandlePrevNextClick(Direction direction)
     {
         // Change current sector and page index values based on direction
@@ -219,27 +223,29 @@ public class TopicDiscussionManager : MonoBehaviour
 
         UpdatePageJumpButtonColors();
     }
+#endregion
 
+#region Discussion Scene Close Related Buttons
     private void HandleBackToMainMenuClick()
     {
-        // Save read pages data and load main menu scene
-        discussionPagesDisplay.SaveReadPagesData();
-        sceneNavigationDisplay.LoadMainMenu();
+        SaveReadPagesDataToDB(_topicDiscussionNumber);
     }
     private void HandleStartActivityClick()
     {
-        // Save read pages data and load specified activity scene
-        discussionPagesDisplay.SaveReadPagesData();
-        sceneNavigationDisplay.LoadActivity(_topicDiscussionNumber);
+        //// Save read pages data and load specified activity scene
+        //discussionPagesDisplay.RecordReadPagesData();
+        //sceneNavigationDisplay.LoadActivity(_topicDiscussionNumber);
     }
     private void HandleBackToGameClick()
     {
-        // Save read pages data and close current discussion scene
-        discussionPagesDisplay.SaveReadPagesData();
-        sceneNavigationDisplay.CloseCurrentDiscussion(_topicDiscussionNumber);
+        //// Save read pages data and close current discussion scene
+        //discussionPagesDisplay.RecordReadPagesData();
+        //sceneNavigationDisplay.CloseCurrentDiscussion(_topicDiscussionNumber);
 
     }
+#endregion
 
+#region Helper Functions
     private void ChangePreviousAndNextButtonState()
     {
         /* Set the current sector's pages count, previous sector title,next sector title, and update
@@ -307,4 +313,198 @@ public class TopicDiscussionManager : MonoBehaviour
             pageJumpDisplay.UpdatePageJumpButtonColor(_currentSectorIndex, isPageMarkedRead, i);
         }
     }
+#endregion
+
+#region Database Functionalities
+    private void SaveReadPagesDataToDB(int topicDiscussionNumber)
+    {
+        // Create generalize data to be used in all cases
+        Dictionary<string, List<int>> recordedMarkedPages = discussionPagesDisplay.RecordReadPagesData();
+        List<List<object>> sectors;
+        Dictionary<string, FirestoreField> updatedFields;
+
+        //To Do: Add a checker to see if the recordedMarkedPages is == to the current discussion's 
+
+        string currentUserLocalID = UserManager.Instance.CurrentUser.localId;
+
+        switch (topicDiscussionNumber)
+        {
+            case 1: // 5 Sectors
+                // Create the appropriate amount of lists needed for a discussion's sector count
+                sectors = new List<List<object>>()
+                {
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                };
+
+                // Process and create the updated fields dictionary
+                updatedFields = CreateUpdatedFieldsDictionary(sectors, recordedMarkedPages);
+                StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionOnePageProgress", currentUserLocalID, OnPagesSaveResult));
+                break;
+
+            case 2: // 4 Sectors
+                // Create the appropriate amount of lists needed for a discussion's sector count
+                sectors = new List<List<object>>()
+                {
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                };
+
+                // Process and create the updated fields dictionary
+                updatedFields = CreateUpdatedFieldsDictionary(sectors, recordedMarkedPages);
+                StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionTwoPageProgress", currentUserLocalID, OnPagesSaveResult));
+                break;
+
+            case 3: // 3 Sectors
+                // Create the appropriate amount of lists needed for a discussion's sector count
+                sectors = new List<List<object>>()
+                {
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                };
+
+                // Process and create the updated fields dictionary
+                updatedFields = CreateUpdatedFieldsDictionary(sectors, recordedMarkedPages);
+                StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionThreePageProgress", currentUserLocalID, OnPagesSaveResult));
+                break;
+
+            case 4: // 3 Sectors
+                // Create the appropriate amount of lists needed for a discussion's sector count
+                sectors = new List<List<object>>()
+                {
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                };
+
+                // Process and create the updated fields dictionary
+                updatedFields = CreateUpdatedFieldsDictionary(sectors, recordedMarkedPages);
+                StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionFourPageProgress", currentUserLocalID, OnPagesSaveResult));
+                break;
+
+            case 5: // 3 Sectors
+                // Create the appropriate amount of lists needed for a discussion's sector count
+                sectors = new List<List<object>>()
+                {
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                };
+
+                // Process and create the updated fields dictionary
+                updatedFields = CreateUpdatedFieldsDictionary(sectors, recordedMarkedPages);
+                StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionFivePageProgress", currentUserLocalID, OnPagesSaveResult));
+                break;
+
+            case 6: // 4 Sectors
+                // Create the appropriate amount of lists needed for a discussion's sector count
+                sectors = new List<List<object>>()
+                {
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                };
+
+                // Process and create the updated fields dictionary
+                updatedFields = CreateUpdatedFieldsDictionary(sectors, recordedMarkedPages);
+                StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionSixPageProgress", currentUserLocalID, OnPagesSaveResult));
+                break;
+
+            case 7: // 4 Sectors
+                // Create the appropriate amount of lists needed for a discussion's sector count
+                sectors = new List<List<object>>()
+                {
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                };
+
+                // Process and create the updated fields dictionary
+                updatedFields = CreateUpdatedFieldsDictionary(sectors, recordedMarkedPages);
+                StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionSevenPageProgress", currentUserLocalID, OnPagesSaveResult));
+                break;
+
+            case 8: // 4 Sectors
+                // Create the appropriate amount of lists needed for a discussion's sector count
+                sectors = new List<List<object>>()
+                {
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                    new List<object>(),
+                };
+
+                // Process and create the updated fields dictionary
+                updatedFields = CreateUpdatedFieldsDictionary(sectors, recordedMarkedPages);
+                StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionEigthPageProgress", currentUserLocalID, OnPagesSaveResult));
+                break;
+
+            case 9: // 2 Sectors
+                // Create the appropriate amount of lists needed for a discussion's sector count
+                sectors = new List<List<object>>()
+                {
+                    new List<object>(),
+                    new List<object>(),
+                };
+
+                // Process and create the updated fields dictionary
+                updatedFields = CreateUpdatedFieldsDictionary(sectors, recordedMarkedPages);
+                StartCoroutine(UserManager.Instance.UpdateDiscussionPageProgress(updatedFields, "discussionNinePageProgress", currentUserLocalID, OnPagesSaveResult));
+                break;
+        }
+    }
+
+    private void OnPagesSaveResult(bool success)
+    {
+        if (success)
+        {
+            SceneManager.LoadScene("Main Menu");
+        }
+        else
+        {
+            Debug.LogError("Marked Pages Data was not saved");
+        }
+    }
+
+    private Dictionary<string, FirestoreField> CreateUpdatedFieldsDictionary(List<List<object>> sectors, Dictionary<string, List<int>> recordedMarkedPages)
+    {
+        // Add the values of each array from the recorded marked pages as FirestoreField data
+        for (int i = 0; i < sectors.Count; i++)
+        {
+            foreach (var value in recordedMarkedPages[$"sector{i + 1}"])
+            {
+                sectors[i].Add(new FirestoreField(value));
+            }
+        }
+
+        // Create the sectorListPairs dictionary to be used in the markedPages Dictionary
+        Dictionary<string, object> sectorListPairs = new Dictionary<string, object>();
+
+        // Add all sector key and array values that were converted to FirestoreField data
+        for (int i = 0; i < sectors.Count; i++)
+        {
+            sectorListPairs[$"sector{i + 1}"] = new { arrayValue = new { values = sectors[i] } };
+        }
+
+        Dictionary<string, object> markedPages = new Dictionary<string, object>()
+        {
+            {"fields", sectorListPairs}
+        };
+
+        Dictionary<string, FirestoreField> updatedFields = new Dictionary<string, FirestoreField>()
+        {
+            {"markedPages", new FirestoreField(markedPages) }
+        };
+
+        return updatedFields;
+    }
+#endregion
 }

--- a/Assets/Scripts/Topic Discussion/UI/Discussion Pages/DiscussionPagesDisplay.cs
+++ b/Assets/Scripts/Topic Discussion/UI/Discussion Pages/DiscussionPagesDisplay.cs
@@ -102,7 +102,7 @@ public class DiscussionPagesDisplay : MonoBehaviour
         }
     }
 
-    public Dictionary<string, List<int>> SaveReadPagesData()
+    public Dictionary<string, List<int>> RecordReadPagesData()
     {
         Dictionary<string, List<int>> newReadPagesMapData = new Dictionary<string, List<int>>();
 
@@ -121,7 +121,7 @@ public class DiscussionPagesDisplay : MonoBehaviour
                 }
             }
 
-            string sectorKey = "sector "+(i + 1);
+            string sectorKey = "sector"+(i + 1);
             newReadPagesMapData[sectorKey] = currentSectorReadPages;
         }
 

--- a/Assets/Scripts/Topic Discussion/UI/Discussion Pages/DiscussionPagesDisplay.cs
+++ b/Assets/Scripts/Topic Discussion/UI/Discussion Pages/DiscussionPagesDisplay.cs
@@ -79,25 +79,29 @@ public class DiscussionPagesDisplay : MonoBehaviour
     public void LoadReadPagesData(Dictionary<string, List<int>> readPagesMapData)
     {
         // Get the list of keys from dictionary
-        List<string> sectorNames = new List<string>(readPagesMapData.Keys);
+        //List<string> sectorNames = new List<string>(readPagesMapData.Keys);
 
-        // Loop through the indices of the key list
-        for (int i = 0; i < sectorNames.Count; i++)
+        foreach(var sectorName in readPagesMapData)
         {
-            string sectorName = sectorNames[i];
-            List<int> readPagesIndexes = readPagesMapData[sectorName];
-            
-            // Set specified pages to have been read state based on the read pages map data
-            foreach(int index in readPagesIndexes)
+            if (sectorName.Key == "sector1")
             {
-                if (index < subTopicsList[i].pages.Count)
-                {
-                    subTopicsList[i].pages[index].isMarkedRead = true;
-                }
-                else
-                {
-                    Debug.Log("Index is out of bounds. Index is greater than the current sector's pages count");
-                }
+                SetPagesMarkedRead(sectorName.Value, 0);
+            }
+            if (sectorName.Key == "sector2")
+            {
+                SetPagesMarkedRead(sectorName.Value, 1);
+            }
+            if (sectorName.Key == "sector3")
+            {
+                SetPagesMarkedRead(sectorName.Value, 2);
+            }
+            if (sectorName.Key == "sector4")
+            {
+                SetPagesMarkedRead(sectorName.Value, 3);
+            }
+            if (sectorName.Key == "sector5")
+            {
+                SetPagesMarkedRead(sectorName.Value, 4);
             }
         }
     }
@@ -126,6 +130,22 @@ public class DiscussionPagesDisplay : MonoBehaviour
         }
 
         return newReadPagesMapData;
+    }
+
+    // Helper function of LoadReadPagesData
+    private void SetPagesMarkedRead(List<int> sectorReadDataList, int index)
+    {
+        foreach (int value  in sectorReadDataList)
+        {
+            if (value < subTopicsList[index].pages.Count)
+            {
+                subTopicsList[index].pages[value].isMarkedRead = true;
+            }
+            else
+            {
+                Debug.Log("Index is out of bounds. Index is greater than the current sector's pages count");
+            }
+        }
     }
 
     #region Page Animation

--- a/Assets/Scripts/User Management/UserManager.cs
+++ b/Assets/Scripts/User Management/UserManager.cs
@@ -265,13 +265,13 @@ public class UserManager : MonoBehaviour
         }
         else
         {
-            Debug.LogError("Failed to retrieve discussion pages: " + request.downloadHandler.text);
+            Debug.Log("Failed to retrieve discussion pages: " + request.downloadHandler.text);
             callback(false);
         }
     }
 
 	// Method to update discussion pages progress document of the current user
-    public IEnumerator UpdateDiscussionPageProgress(Dictionary<string, FirestoreField> updatedFields, string collectionName, string studentID, System.Action<bool> callback)
+    public IEnumerator UpdateDiscussionPageProgress(Dictionary<string, FirestoreField> updatedFields, string collectionName, string studentID)
 	{
 		string url = $"https://firestore.googleapis.com/v1/projects/physix-9c8bd/databases/(default)/documents/{collectionName}/{studentID}";
 
@@ -292,12 +292,10 @@ public class UserManager : MonoBehaviour
         if (request.result == UnityWebRequest.Result.Success)
         {
             Debug.Log($"{collectionName} document updated successfully!");
-			callback(true);
         }
         else
         {
             Debug.LogError($"Failed to update document {collectionName}: " + request.downloadHandler.text);
-            callback(false);
         }
     }
 }

--- a/Assets/Scripts/User Management/UserManager.cs
+++ b/Assets/Scripts/User Management/UserManager.cs
@@ -71,8 +71,17 @@ public class UserManager : MonoBehaviour
 
 	public FirebaseAuthResponse CurrentUser { get; private set; }
 	public FirestoreDocument UserData { get; private set; }
+	public FirestoreDocument DiscussionOneMarkedPagesData { get; private set; }
+    public FirestoreDocument DiscussionTwoMarkedPagesData { get; private set; }
+    public FirestoreDocument DiscussionThreeMarkedPagesData { get; private set; }
+    public FirestoreDocument DiscussionFourMarkedPagesData { get; private set; }
+    public FirestoreDocument DiscussionFiveMarkedPagesData { get; private set; }
+    public FirestoreDocument DiscussionSixMarkedPagesData { get; private set; }
+    public FirestoreDocument DiscussionSevenMarkedPagesData { get; private set; }
+    public FirestoreDocument DiscussionEightMarkedPagesData { get; private set; }
+    public FirestoreDocument DiscussionNineMarkedPagesData { get; private set; }
 
-	private void Awake()
+    private void Awake()
 	{
 		if (Instance != null && Instance != this)
 		{
@@ -202,7 +211,67 @@ public class UserManager : MonoBehaviour
 		}
 	}
 
-	public IEnumerator UpdateDiscussionPageProgress(Dictionary<string, FirestoreField> updatedFields, string collectionName, string studentID, System.Action<bool> callback)
+	// Method to get discussion pages progress document of the current user
+    public IEnumerator GetDiscussionPagesProgress(int topicDiscussionNumber, string collectionName, string documentId, System.Action<bool> callback)
+    {
+		string url = $"https://firestore.googleapis.com/v1/projects/physix-9c8bd/databases/(default)/documents/{collectionName}/{documentId}";
+        UnityWebRequest request = UnityWebRequest.Get(url);
+        request.SetRequestHeader("Authorization", "Bearer " + CurrentUser.idToken);
+
+        yield return request.SendWebRequest();
+
+        if (request.result == UnityWebRequest.Result.Success)
+        {
+			switch (topicDiscussionNumber)
+			{
+				case 1:
+                    DiscussionOneMarkedPagesData = JsonConvert.DeserializeObject<FirestoreDocument>(request.downloadHandler.text);
+                    break;
+
+                case 2:
+                    DiscussionTwoMarkedPagesData = JsonConvert.DeserializeObject<FirestoreDocument>(request.downloadHandler.text);
+                    break;
+
+                case 3:
+                    DiscussionThreeMarkedPagesData = JsonConvert.DeserializeObject<FirestoreDocument>(request.downloadHandler.text);
+                    break;
+
+                case 4:
+                    DiscussionFourMarkedPagesData = JsonConvert.DeserializeObject<FirestoreDocument>(request.downloadHandler.text);
+                    break;
+
+                case 5:
+                    DiscussionFiveMarkedPagesData = JsonConvert.DeserializeObject<FirestoreDocument>(request.downloadHandler.text);
+                    break;
+
+                case 6:
+                    DiscussionSixMarkedPagesData = JsonConvert.DeserializeObject<FirestoreDocument>(request.downloadHandler.text);
+                    break;
+
+                case 7:
+                    DiscussionSevenMarkedPagesData = JsonConvert.DeserializeObject<FirestoreDocument>(request.downloadHandler.text);
+                    break;
+
+                case 8:
+                    DiscussionEightMarkedPagesData = JsonConvert.DeserializeObject<FirestoreDocument>(request.downloadHandler.text);
+                    break;
+
+                case 9:
+                    DiscussionNineMarkedPagesData = JsonConvert.DeserializeObject<FirestoreDocument>(request.downloadHandler.text);
+                    break;
+            }
+            Debug.Log("Discussion Pages retrieved successfully!");
+            callback(true);
+        }
+        else
+        {
+            Debug.LogError("Failed to retrieve discussion pages: " + request.downloadHandler.text);
+            callback(false);
+        }
+    }
+
+	// Method to update discussion pages progress document of the current user
+    public IEnumerator UpdateDiscussionPageProgress(Dictionary<string, FirestoreField> updatedFields, string collectionName, string studentID, System.Action<bool> callback)
 	{
 		string url = $"https://firestore.googleapis.com/v1/projects/physix-9c8bd/databases/(default)/documents/{collectionName}/{studentID}";
 

--- a/Assets/Scripts/User Management/UserManager.cs
+++ b/Assets/Scripts/User Management/UserManager.cs
@@ -224,9 +224,28 @@ public class UserManager : MonoBehaviour
 	}
 
 
-	// Three functions that I added for main menu and topic discussion //
-	// Method to get section name from student's section Id
-	public IEnumerator GetSectionDocument(string documentId, System.Action<bool> callback)
+    // Four functions that I added for logging out, main menu and topic discussion //
+    // Method to get section name from student's section Id
+    public IEnumerator LogoutCurrentUser()
+    {
+        CurrentUser = null;
+        UserData = null;
+        UserSection = null;
+        DiscussionOneMarkedPagesData = null;
+        DiscussionTwoMarkedPagesData = null;
+        DiscussionThreeMarkedPagesData = null;
+        DiscussionFourMarkedPagesData = null;
+        DiscussionFiveMarkedPagesData = null;
+        DiscussionSixMarkedPagesData = null;
+        DiscussionSevenMarkedPagesData = null;
+        DiscussionEightMarkedPagesData = null;
+        DiscussionNineMarkedPagesData = null;
+
+		Debug.Log("Logout Successful");
+        yield break;
+    }
+
+    public IEnumerator GetSectionDocument(string documentId, System.Action<bool> callback)
 	{
 		string url = $"https://firestore.googleapis.com/v1/projects/physix-9c8bd/databases/(default)/documents/sections/{documentId}";
 		UnityWebRequest request = UnityWebRequest.Get(url);


### PR DESCRIPTION
This PR adds functionality to load and save the player's marked pages data from and to the database for the game.
This PR also adds functionality to load and display necessary player information in the main menu with a logout function.
This covers the marked pages data for topic discussion 1 - 9 of the game.